### PR TITLE
2.0.0

### DIFF
--- a/Example/YoonitCameraDemo/YoonitCameraDemo/Base.lproj/Main.storyboard
+++ b/Example/YoonitCameraDemo/YoonitCameraDemo/Base.lproj/Main.storyboard
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="l7p-dQ-FCU">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -14,16 +12,16 @@
             <objects>
                 <viewController id="l7p-dQ-FCU" customClass="CameraViewController" customModule="YoonitCameraDemo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="hFs-or-lPB">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="s7c-6p-oqC" customClass="CameraView" customModule="YoonitCamera">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CFI-Hd-ktB">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZQn-f6-cka">
@@ -38,7 +36,7 @@
                                         </connections>
                                     </button>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cye-Bx-CYr">
-                                        <rect key="frame" x="206" y="654" width="200" height="200"/>
+                                        <rect key="frame" x="392" y="358" width="200" height="200"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJp-iv-opc">
@@ -87,7 +85,7 @@
                                         <rect key="frame" x="8" y="195" width="49" height="31"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <connections>
-                                            <action selector="toggleFaceSaveImage:" destination="l7p-dQ-FCU" eventType="valueChanged" id="Hvd-WA-6PC"/>
+                                            <action selector="toggleSaveImageCaptured:" destination="l7p-dQ-FCU" eventType="valueChanged" id="Hvd-WA-6PC"/>
                                         </connections>
                                     </switch>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Face Save Image" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sbc-gW-phy">

--- a/Example/YoonitCameraDemo/YoonitCameraDemo/CameraViewController.swift
+++ b/Example/YoonitCameraDemo/YoonitCameraDemo/CameraViewController.swift
@@ -22,6 +22,39 @@ class CameraViewController: UIViewController {
     
     var showImagePreview = false
     
+    var captureType: String = "none" {
+        didSet {
+            switch self.captureType {
+            case "none":
+                self.cameraTypeDropDown.setTitle("No capture", for: .normal)
+                self.clearFaceImagePreview()
+                self.qrCodeTextField.isHidden = true
+                return;
+                
+            case "face":
+                self.cameraTypeDropDown.setTitle("Face capture", for: .normal)
+                self.showImagePreview = true
+                self.qrCodeTextField.isHidden = true
+                return;
+                
+            case "frame":
+                self.cameraTypeDropDown.setTitle("Frame capture", for: .normal)
+                self.showImagePreview = true
+                self.qrCodeTextField.isHidden = true
+                return;
+                
+            case "qrcode":
+                self.cameraTypeDropDown.setTitle("Code capture", for: .normal)
+                self.qrCodeTextField.isHidden = false
+                self.clearFaceImagePreview()
+                return;
+                
+            default:
+                return;
+            }
+        }
+    }
+    
     let menu: DropDown = {
         let menu = DropDown()
         menu.dataSource = [
@@ -59,49 +92,41 @@ class CameraViewController: UIViewController {
         self.cameraView.startPreview()        
         
         self.menu.anchorView = self.cameraTypeDropDown
-        self.menu.selectionAction = { index, title in
-            var captureType = "none"
-            
-            if (title == "No capture") {
-                self.cameraTypeDropDown.setTitle("No capture", for: .normal)
-                captureType = "none"
-                self.clearFaceImagePreview()
-                self.qrCodeTextField.isHidden = true
+        self.menu.selectionAction = {
+            index, title in
+                        
+            switch title {
+            case "No capture":
+                self.captureType = "none"
+                break;
                 
-            } else if (title == "Face capture") {
-                self.cameraTypeDropDown.setTitle("Face capture", for: .normal)
-                captureType = "face"
-                self.showImagePreview = true
-                self.qrCodeTextField.isHidden = true
+            case "Face capture":
+                self.captureType = "face"
+                break;
                 
-            } else if (title == "Code capture") {
-                self.cameraTypeDropDown.setTitle("Code capture", for: .normal)
-                captureType = "qrcode"
-                self.qrCodeTextField.isHidden = false
-                self.clearFaceImagePreview()
+            case "Frame capture":
+                self.captureType = "frame"
+                break;
                 
-            } else if (title == "Frame capture") {
-                self.cameraTypeDropDown.setTitle("Frame capture", for: .normal)
-                captureType = "frame"
-                self.showImagePreview = true
-                self.qrCodeTextField.isHidden = true
+            case "Code capture":
+                self.captureType = "qrcode"
+                break;
+                
+            default:
+                self.captureType = "none"
+                break;
             }
             
-            self.cameraView.startCaptureType(captureType: captureType)
+            self.cameraView.startCaptureType(captureType: self.captureType)
         }
     }
         
     @objc func onBackground(_ notification: Notification) {
-        // For testing...
-        
         self.cameraView.stopCapture()
     }
     
     @objc func onActive(_ notification: Notification) {
-        // For testing...
-        
         self.cameraView.startPreview()
-//        self.cameraView.startCaptureType(captureType: "face")
     }
   
     @IBAction func toggleCam(_ sender: UIButton) {

--- a/Example/YoonitCameraDemo/YoonitCameraDemo/CameraViewController.swift
+++ b/Example/YoonitCameraDemo/YoonitCameraDemo/CameraViewController.swift
@@ -174,7 +174,7 @@ class CameraViewController: UIViewController {
 
 extension CameraViewController: CameraEventListenerDelegate {
     
-    func onImageCreated(
+    func onImageCaptured(
         type: String,
         count: Int,
         total: Int,

--- a/Example/YoonitCameraDemo/YoonitCameraDemo/CameraViewController.swift
+++ b/Example/YoonitCameraDemo/YoonitCameraDemo/CameraViewController.swift
@@ -151,11 +151,11 @@ class CameraViewController: UIViewController {
     }
     
     @IBAction func toggleFaceDetectionBox(_ sender: UISwitch) {
-        self.cameraView.setFaceDetectionBox(faceDetectionBox: sender.isOn)
+        self.cameraView.setFaceDetectionBox(enable: sender.isOn)
     }
     
-    @IBAction func toggleFaceSaveImage(_ sender: UISwitch) {
-        self.cameraView.setFaceSaveImages(faceSaveImages: sender.isOn)
+    @IBAction func toggleSaveImageCaptured(_ sender: UISwitch) {
+        self.cameraView.setSaveImageCaptured(enable: sender.isOn)
         
         if !sender.isOn {
             self.clearFaceImagePreview()

--- a/Example/YoonitCameraDemo/YoonitCameraDemo/CameraViewController.swift
+++ b/Example/YoonitCameraDemo/YoonitCameraDemo/CameraViewController.swift
@@ -76,7 +76,7 @@ class CameraViewController: UIViewController {
                 
             } else if (title == "Code capture") {
                 self.cameraTypeDropDown.setTitle("Code capture", for: .normal)
-                captureType = "barcode"
+                captureType = "qrcode"
                 self.qrCodeTextField.isHidden = false
                 self.clearFaceImagePreview()
                 
@@ -149,27 +149,19 @@ class CameraViewController: UIViewController {
 
 extension CameraViewController: CameraEventListenerDelegate {
     
-    func onFaceImageCreated(count: Int, total: Int, imagePath: String) {
+    func onImageCreated(
+        type: String,
+        count: Int,
+        total: Int,
+        imagePath: String) {
+        
         let subpath = imagePath.substring(from: imagePath.index(imagePath.startIndex, offsetBy: 7))
         let image = UIImage(contentsOfFile: subpath)
         
         if total == 0 {
-            print("onImageCaptured: \(count).")
+            print("onImageCaptured \(type): \(count).")
         } else {
-            print("onImageCaptured: \(count) from \(total).")
-        }
-        
-        self.savedFrame.image = self.showImagePreview ? image : nil
-    }
-    
-    func onFrameImageCreated(count: Int, total: Int, imagePath: String) {
-        let subpath = imagePath.substring(from: imagePath.index(imagePath.startIndex, offsetBy: 7))
-        let image = UIImage(contentsOfFile: subpath)
-        
-        if total == 0 {
-            print("onImageCaptured: \(count).")
-        } else {
-            print("onImageCaptured: \(count) from \(total).")
+            print("onImageCaptured \(type): \(count) from \(total).")
         }
         
         self.savedFrame.image = self.showImagePreview ? image : nil
@@ -201,8 +193,8 @@ extension CameraViewController: CameraEventListenerDelegate {
         print("onPermissionDenied")
     }
 
-    func onBarcodeScanned(content: String) {
-        print("onBarcodeScanned: \(content)")
+    func onQRCodeScanned(content: String) {
+        print("onQRCodeScanned: \(content)")
         self.qrCodeTextField.text = content
     }
 }

--- a/Example/YoonitCameraDemo/YoonitCameraDemo/CameraViewController.swift
+++ b/Example/YoonitCameraDemo/YoonitCameraDemo/CameraViewController.swift
@@ -197,6 +197,8 @@ extension CameraViewController: CameraEventListenerDelegate {
     }
     
     func onFaceUndetected() {
+        print("onFaceUndetected")
+        
         DispatchQueue.main.async {
             self.savedFrame.image = nil
         }

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ class YourViewController: UIViewController, CameraEventListenerDelegate {
     ...
     self.cameraView.cameraEventListener = self
     ...
-    func onFaceImageCreated(count: Int, total: Int, imagePath: String) {
+    func onImageCaptured(type: String, count: Int, total: Int, imagePath: String) {
         // YOUR CODE
     }
 }
@@ -108,12 +108,12 @@ class YourViewController: UIViewController, CameraEventListenerDelegate {
 | **`setTimeBetweenImages`**      | `timeBetweenImages: Int64`                                                     | Any positive number that represent time in milli seconds                          | void        | Set saving face/frame images time interval in milli seconds.
 | **`setOutputImageWidth`**       | `width: Int`                                                                  | Any positive `number` value that represents in pixels                             | void        | Set face image width to be created in pixels.
 | **`setOutputImageHeight`**      | `height: Int`                                                                 | Any positive `number` value that represents in pixels                             | void        | Set face image height to be created in pixels.
-| **`setFaceDetectionBox`**       | `faceDetectionBox: Bool`                                                      | `true` or `false`                                                                 | void        | Set to show a detection box when face detected.   
+| **`setSaveImageCaptured`**      | `enable: Bool`                                                     | `true` or `false`                                                                 | void        | Set to enable/disable save image when capturing face and frame.
+| **`setFaceDetectionBox`**       | `enable: Bool`                                                      | `true` or `false`                                                                 | void        | Set to show a detection box when face detected.   
 | **`setFacePaddingPercent`**     | `facePaddingPercent: Float`                                                   | Any positive `Float` value                                                        | void        | Set face image and bounding box padding in percent.  
 | **`setFaceCaptureMinSize`**     | `faceCaptureMinSize: Float`                                                   | Value between `0` and `1`. Represents the percentage.                             | void        | Set the minimum face capture based on the screen width limit.
 | **`setFaceCaptureMaxSize`**     | `faceCaptureMaxSize: Float`                                                   | Value between `0` and `1`. Represents the percentage.                             | void        | Set the maximum face capture based on the screen width limit.
-| **`setFaceSaveImages`**         | `faceSaveImages: Bool`                                                        | `true` or `false`                                                                 | void        | Set to enable/disable face save images when capturing faces.
-| **`setFaceROIEnable`**          | `faceROIEnable: Bool`                                                         | `true` or `false`                                                                 | void        | Enable/disable face region of interest capture.
+| **`setFaceROIEnable`**          | `enable: Bool`                                                         | `true` or `false`                                                                 | void        | Enable/disable face region of interest capture.
 | **`setFaceROIOffset`**          | `topOffset: Float, rightOffset: Float,bottomOffset: Float, leftOffset: Float` | Values between `0` and `1`. Represents the percentage.                            | void        | <ul><li>topOffset: "Above" the face detected.</li><li>rightOffset: "Right" of the face detected.</li><li>bottomOffset: "Bottom" of the face detected.</li><li>leftOffset: "Left" of the face detected.</li></ul>
 | **`setFaceROIMinSize`**         | `minimumSize: Float`                                                          | Values between `0` and `1`. Represents the percentage.                            | void        | Set the minimum face size related with the region of interest.  
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ pod install
 ```  
 
 ## Usage  
-  All the functionalities that the `ios-yoonit-camera` provides is accessed through the `CameraView`, that includes the camera preview.  Below we have the basic usage code, for more details, see the [**Methods**](#methods).
+
+All the functionalities that the `ios-yoonit-camera` provides is accessed through the `CameraView`, that includes the camera preview.  Below we have the basic usage code, for more details, see the [**Methods**](#methods).
 
 ### Camera Preview
 
@@ -76,7 +77,7 @@ class YourViewController: UIViewController, CameraEventListenerDelegate {
 With camera preview, we can start scanning QR codes:
 
 ```swift
-this.cameraView.startCaptureType(captureType: "barcode")
+this.cameraView.startCaptureType(captureType: "qrcode")
 ```
 
 Set camera event listener to get the result:
@@ -86,7 +87,7 @@ class YourViewController: UIViewController, CameraEventListenerDelegate {
     ...
     self.cameraView.cameraEventListener = self
     ...
-    func onBarcodeScanned(content: String) {
+    func onQRCodeScanned(content: String) {
         // YOUR CODE
     }
 }
@@ -96,40 +97,38 @@ class YourViewController: UIViewController, CameraEventListenerDelegate {
 
 ### Methods   
 
-| Function                       | Parameters                    | Return Type | Valid values                                                    | Description
-| -                              | -                             | -           | -                                                               | -  
-| **`startPreview`**             | -                             | void        | -                                                               | Start camera preview if has permission.
-| **`startCaptureType`**          | `captureType: String`          | void        | <ul><li>`"none"`</li><li>`"face"`</li><li>`"barcode"`</li><li>`"frame"`</li></ul> | Set capture type none, face, barcode and frame.
-| **`stopCapture`**              | -                             | void        | -                                                               | Stop any type of capture.
-| **`toggleCameraLens`**         | -                             | void        | -                                                               | Set camera lens facing front or back.
-| **`getCameraLens`**            | -                             | Int         | -                                                               | Return `Int` that represents lens face state: 0 for front 1 for back camera.  
-| **`setFaceNumberOfImages`**    | `faceNumberOfImages: Int`     | void        | Any positive `Int` value                                        | Default value is 0. For value 0 is saved infinity images. When saved images reached the "face number os images", the `onEndCapture` is triggered.
-| **`setFaceDetectionBox`**      | `faceDetectionBox: Bool`   | void        | `true` or `false`                                               | Set to show face detection box when face detected.   
-| **`setFaceTimeBetweenImages`** | `faceTimeBetweenImages: Int64` | void        | Any positive number that represent time in milli seconds        | Set saving face images time interval in milli seconds.  
-| **`setFacePaddingPercent`**    | `facePaddingPercent: Float`   | void        | Any positive `Float` value                                      | Set face image and bounding box padding in percent.  
-| **`setFaceImageSize`**         | `width: Int, height: Int`     | void        | Any positive `Int` value                                        | Set face image size to be saved.
-| **`setFaceCaptureMinSize`**     | `faceCaptureMinSize: Float`       | void        | Value between `0` and `1`. Represents the percentage.                             | void        | Set the minimum face capture based on the screen width limit.
-| **`setFaceCaptureMaxSize`**     | `faceCaptureMaxSize: Float`       | void        | Value between `0` and `1`. Represents the percentage.                            | Set the maximum face capture based on the screen width limit.
-| **`setFrameTimeBetweenImages`** | `frameTimeBetweenImages: Int64` | void        | Any positive number that represent time in milli seconds                          | Set saving frame images time interval in milli seconds.
-| **`setFrameNumberOfImages`** |  `frameNumberOfImages: Int` | void | Any positive `Int` value | Default value is 0. For value 0 is saved infinity images. When saved images reached the "frame number os images", the `onEndCapture` is triggered.
-| **`setFaceSaveImages`** | `faceSaveImages: Boolean` | `true` or `false` | void | Set to enable/disable face save images when capturing faces.
-|  **`setFaceROIEnable`** |  `faceROIEnable: Bool` | void |  `true` or `false` | Enable/disable face region of interest capture.
-|  **`setFaceROIOffset`** |  `topOffset: Float, rightOffset: Float,bottomOffset: Float, leftOffset: Float` | void | Values between `0` and `1`. Represents the percentage. | <ul><li>topOffset: "Above" the face detected.</li><li>rightOffset: "Right" of the face detected.</li><li>bottomOffset: "Bottom" of the face detected.</li><li>leftOffset: "Left" of the face detected.</li></ul>
-| **`setFaceROIMinSize`** | `minimumSize: Float` | void | Values between `0` and `1`. Represents the percentage. | Set the minimum face size related with the region of interest.
+| Function                        | Parameters                                                                    | Valid values                                                                      | Return Type | Description
+| -                               | -                                                                             | -                                                                                 | -           | -  
+| **`startPreview`**              | -                                                                             | -                                                                                 | void        | Start camera preview if has permission.
+| **`startCaptureType`**          | `captureType: String`                                                         | <ul><li>`"none"`</li><li>`"face"`</li><li>`"qcode"`</li><li>`"frame"`</li></ul> | void        | Set capture type none, face, QR Code or frame.
+| **`stopCapture`**               | -                                                                             | -                                                                                 | void        | Stop any type of capture.
+| **`toggleCameraLens`**          | -                                                                             | -                                                                                 | void        | Set camera lens facing front or back.
+| **`getCameraLens`**             | -                                                                             | -                                                                                 | Int         | Return `Int` that represents lens face state: 0 for front 1 for back camera.  
+| **`setNumberOfImages`**         | `numberOfImages: Int`                                                         | Any positive `Int` value                                                          | void        | Default value is 0. For value 0 is saved infinity images. When saved images reached the "number os images", the `onEndCapture` is triggered.
+| **`setTimeBetweenImages`**      | `timeBetweenImages: Int64`                                                     | Any positive number that represent time in milli seconds                          | void        | Set saving face/frame images time interval in milli seconds.
+| **`setOutputImageWidth`**       | `width: Int`                                                                  | Any positive `number` value that represents in pixels                             | void        | Set face image width to be created in pixels.
+| **`setOutputImageHeight`**      | `height: Int`                                                                 | Any positive `number` value that represents in pixels                             | void        | Set face image height to be created in pixels.
+| **`setFaceDetectionBox`**       | `faceDetectionBox: Bool`                                                      | `true` or `false`                                                                 | void        | Set to show a detection box when face detected.   
+| **`setFacePaddingPercent`**     | `facePaddingPercent: Float`                                                   | Any positive `Float` value                                                        | void        | Set face image and bounding box padding in percent.  
+| **`setFaceCaptureMinSize`**     | `faceCaptureMinSize: Float`                                                   | Value between `0` and `1`. Represents the percentage.                             | void        | Set the minimum face capture based on the screen width limit.
+| **`setFaceCaptureMaxSize`**     | `faceCaptureMaxSize: Float`                                                   | Value between `0` and `1`. Represents the percentage.                             | void        | Set the maximum face capture based on the screen width limit.
+| **`setFaceSaveImages`**         | `faceSaveImages: Bool`                                                        | `true` or `false`                                                                 | void        | Set to enable/disable face save images when capturing faces.
+| **`setFaceROIEnable`**          | `faceROIEnable: Bool`                                                         | `true` or `false`                                                                 | void        | Enable/disable face region of interest capture.
+| **`setFaceROIOffset`**          | `topOffset: Float, rightOffset: Float,bottomOffset: Float, leftOffset: Float` | Values between `0` and `1`. Represents the percentage.                            | void        | <ul><li>topOffset: "Above" the face detected.</li><li>rightOffset: "Right" of the face detected.</li><li>bottomOffset: "Bottom" of the face detected.</li><li>leftOffset: "Left" of the face detected.</li></ul>
+| **`setFaceROIMinSize`**         | `minimumSize: Float`                                                          | Values between `0` and `1`. Represents the percentage.                            | void        | Set the minimum face size related with the region of interest.  
 
 ### Events
 
-| Event                    | Parameters                                  | Description
-| -                        | -                                           | -
-| **`onFaceImageCreated`** | `count: Int, total: Int, imagePath: String` | Must have started capture type of face (see `startCaptureType`). Emitted when the face image file is created: <ul><li>count: current index</li><li>total: total to create</li><li>imagePath: the face image path</li><ul>
-| **`onFrameImageCreated`** | `count: Int, total: Int, imagePath: String` | Must have started capture type of frame (see `startCaptureType`). Emitted when the frame image file is created: <ul><li>count: current index</li><li>total: total to create</li><li>imagePath: the frame image path</li><ul>
-| **`onFaceDetected`**     | `x: Int, y: Int, width: Int, height: Int`   | Must have started capture type of face. Emit the detected face bounding box.
-| **`onFaceUndetected`**   | -                                           | Must have started capture type of face. Emitted after `onFaceDetected`, when there is no more face detecting.
-| **`onEndCapture`**        | -                                           | Must have started capture type of face or frame. Emitted when the number of face or frame image files created is equal of the number of images set (see the method `setFaceNumberOfImages` for face and `setFrameNumberOfImages` for frame).   
-| **`onBarcodeScanned`**   | `content: String`                           | Must have started capture type of barcode (see `startCaptureType`). Emitted when the camera scan a QR Code.   
-| **`onError`**             | `error: String`                             | Emit message error. Argument may be a string or an pre-defined[**KeyError**](###KeyError).
-| **`onMessage`**           | `message: String`                           | Emit message. Argument may be a string or an pre-defined[**Message**](###Message).   
-| **`onPermissionDenied`** | -                                           | Emit when try to `startPreview` but there is not camera permission.
+| Event                     | Parameters                                                | Description
+| -                         | -                                                         | -
+| **`onImageCaptured`**     | `type: String, count: Int, total: Int, imagePath: String` | Must have started capture type of face/frame (see `startCaptureType`). Emitted when the face image file is created: <ul><li>type: 'face' | 'frame'</li><li>count: current index</li><li>total: total to create</li><li>imagePath: the image path</li><ul>  
+| **`onFaceDetected`**      | `x: Int, y: Int, width: Int, height: Int`                 | Must have started capture type of face. Emit the detected face bounding box.
+| **`onFaceUndetected`**    | -                                                         | Must have started capture type of face. Emitted after `onFaceDetected`, when there is no more face detecting.
+| **`onEndCapture`**        | -                                                         | Must have started capture type of face or frame. Emitted when the number of image files created is equal of the number of images set (see the method `setNumberOfImages`).   
+| **`onQRCodeScanned`**     | `content: String`                                         | Must have started capture type of qrcode (see `startCaptureType`). Emitted when the camera scan a QR Code.   
+| **`onError`**             | `error: String`                                           | Emit message error.
+| **`onMessage`**           | `message: String`                                         | Emit message.
+| **`onPermissionDenied`**  | -                                                         | Emit when try to `startPreview` but there is not camera permission.
 
 ### KeyError
 
@@ -139,26 +138,25 @@ Pre-define key error used by the `onError` event.
 | -                                 | -
 | NOT_STARTED_PREVIEW               | Tried to start a process that depends on to start the camera preview.
 | INVALID_CAPTURE_TYPE              | Tried to start a non-existent capture type.
-| INVALID_FACE_NUMBER_OF_IMAGES     | Tried to input invalid face number of images to capture. 
-| INVALID_FACE_TIME_BETWEEN_IMAGES  | Tried to input invalid face time interval to capture face.
+| INVALID_NUMBER_OF_IMAGES          | Tried to input invalid face/frame number of images to capture. 
+| INVALID_TIME_BETWEEN_IMAGES       | Tried to input invalid face time interval to capture face.
+| INVALID_OUTPUT_IMAGE_WIDTH        | Tried to input invalid image width.
+| INVALID_OUTPUT_IMAGE_HEIGHT       | Tried to input invalid image height.
 | INVALID_FACE_PADDING_PERCENT      | Tried to input invalid face padding percent.
-| INVALID_FACE_IMAGE_SIZE           | Tried to input invalid image width or height.
 | INVALID_FACE_CAPTURE_MIN_SIZE     | Tried to input invalid face capture minimum size. 
 | INVALID_FACE_CAPTURE_MAX_SIZE     | Tried to input invalid face capture maximum size.
-| INVALID_FRAME_NUMBER_OF_IMAGES    | Tried to input invalid frame number of images to capture.
-| INVALID_FRAME_TIME_BETWEEN_IMAGES | Tried to input invalid frame time interval to capture face.
-| INVALID_FACE_ROI_OFFSET | Tried to input invalid face region of interest offset. 
+| INVALID_FACE_ROI_OFFSET           | Tried to input invalid face region of interest offset.
 | INVALID_FACE_ROI_MIN_SIZE         | Tried to input invalid face region of interest minimum size.
 
 ### Message
 
 Pre-define key messages used by the `onMessage` event.
 
-| Message                | Description
-| -                             | -
-| INVALID_CAPTURE_FACE_MIN_SIZE | Face width percentage in relation of the screen width is less than the setted (`setFaceCaptureMinSize`).
-| INVALID_CAPTURE_FACE_MAX_SIZE | Face width percentage in relation of the screen width is more than the setted (`setFaceCaptureMaxSize`).
-| INVALID_CAPTURE_FACE_OUT_OF_ROI | Face bounding box is out of the setted region of interest (`setFaceROIOffset`).
+| Message                           | Description
+| -                                 | -
+| INVALID_CAPTURE_FACE_MIN_SIZE     | Face width percentage in relation of the screen width is less than the setted (`setFaceCaptureMinSize`).
+| INVALID_CAPTURE_FACE_MAX_SIZE     | Face width percentage in relation of the screen width is more than the setted (`setFaceCaptureMaxSize`).
+| INVALID_CAPTURE_FACE_OUT_OF_ROI   | Face bounding box is out of the setted region of interest (`setFaceROIOffset`).
 | INVALID_CAPTURE_FACE_ROI_MIN_SIZE | Face width percentage in relation of the screen width is less than the setted (`setFaceROIMinSize`).
 
 ## To contribute and make it better

--- a/YoonitCamera.xcodeproj/project.pbxproj
+++ b/YoonitCamera.xcodeproj/project.pbxproj
@@ -413,7 +413,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.cyberlabs.YoonitCamera;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -441,7 +441,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.cyberlabs.YoonitCamera;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/YoonitCamera/src/CameraController.swift
+++ b/YoonitCamera/src/CameraController.swift
@@ -95,7 +95,7 @@ class CameraController: NSObject {
      Start capture type of Image Analyzer.
      Must have started preview.
      
-     - Parameter captureType: `.NONE` | `.FACE` | `.BARCODE` | `.FRAME`;
+     - Parameter captureType: `.NONE` | `.FACE` | `.QRCODE` | `.FRAME`;
      - Precondition: Must have started preview.
      */
     public func startCaptureType(captureType: CaptureType) {
@@ -195,7 +195,7 @@ class CameraController: NSObject {
                         
         self.session.addOutput(videoDataOutput)
         
-        // QrCode output capture ========================================
+        // QRCode output capture ========================================
         let metadataOutput = AVCaptureMetadataOutput()
         self.session.addOutput(metadataOutput)
         metadataOutput.setMetadataObjectsDelegate(
@@ -250,7 +250,7 @@ extension CameraController: AVCaptureMetadataOutputObjectsDelegate {
         didOutput metadataObjects: [AVMetadataObject],
         from connection: AVCaptureConnection) {
 
-        if (self.captureOptions.type != CaptureType.BARCODE) {
+        if (self.captureOptions.type != CaptureType.QRCODE) {
             return
         }
         
@@ -258,7 +258,7 @@ extension CameraController: AVCaptureMetadataOutputObjectsDelegate {
             guard let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject else { return }
             guard let stringValue = readableObject.stringValue else { return }
             AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
-            self.cameraEventListener?.onBarcodeScanned(content: stringValue)
+            self.cameraEventListener?.onQRCodeScanned(content: stringValue)
         }
     }
 }

--- a/YoonitCamera/src/CameraView.swift
+++ b/YoonitCamera/src/CameraView.swift
@@ -96,8 +96,8 @@ public class CameraView: UIView {
         case "face":
             self.cameraController?.startCaptureType(captureType: CaptureType.FACE)
             
-        case "barcode":
-            self.cameraController?.startCaptureType(captureType: CaptureType.BARCODE)
+        case "qrcode":
+            self.cameraController?.startCaptureType(captureType: CaptureType.QRCODE)
             
         case "frame":
             self.cameraController?.startCaptureType(captureType: CaptureType.FRAME)
@@ -136,20 +136,33 @@ public class CameraView: UIView {
     }
     
     /**
-     Set number of face file images to create.
-     The time interval to create the image is 1000 milli second.
-     See setFaceTimeBetweenImages to change the time interval.
+     Set number of face/frame file images to create.
      
-     - Parameter faceNumberOfImages: The number of images to create.
+     - Parameter numberOfImages: The number of images to create.
      */
     @objc
-    public func setFaceNumberOfImages(faceNumberOfImages: Int) {
-        if faceNumberOfImages < 0 {
-            self.cameraEventListener?.onError(error: KeyError.INVALID_FACE_NUMBER_OF_IMAGES.rawValue)
+    public func setNumberOfImages(numberOfImages: Int) {
+        if numberOfImages < 0 {
+            self.cameraEventListener?.onError(error: KeyError.INVALID_NUMBER_OF_IMAGES.rawValue)
             return
         }
         
-        self.captureOptions.faceNumberOfImages = faceNumberOfImages
+        self.captureOptions.numberOfImages = numberOfImages
+    }
+    
+    /**
+     Set saving face/frame images time interval in milli seconds.
+     
+     - Parameter faceTimeBetweenImages: The time in milli seconds. Default value is `1000`.
+     */
+    @objc
+    public func setTimeBetweenImages(timeBetweenImages: Int64) {
+        if timeBetweenImages < 0 {
+            self.cameraEventListener?.onError(error: KeyError.INVALID_TIME_BETWEEN_IMAGES.rawValue)
+            return
+        }
+        
+        self.captureOptions.timeBetweenImages = timeBetweenImages
     }
     
     /**
@@ -172,22 +185,7 @@ public class CameraView: UIView {
     public func setFaceSaveImages(faceSaveImages: Bool) {
         self.captureOptions.faceSaveImages = faceSaveImages
     }
-    
-    /**
-     Set saving face images time interval in milli seconds.
-     
-     - Parameter faceTimeBetweenImages: The time in milli seconds. Default value is `1000`.
-     */
-    @objc
-    public func setFaceTimeBetweenImages(faceTimeBetweenImages: Int64) {
-        if faceTimeBetweenImages < 0 {
-            self.cameraEventListener?.onError(error: KeyError.INVALID_FACE_TIME_BETWEEN_IMAGES.rawValue)
-            return
-        }
         
-        self.captureOptions.faceTimeBetweenImages = faceTimeBetweenImages
-    }
-    
     /**
      Enlarge the face bounding box by percent.
      
@@ -259,39 +257,7 @@ public class CameraView: UIView {
         
         self.captureOptions.faceCaptureMaxSize = faceCaptureMaxSize
     }
-    
-    /**
-     Set number of frame file images to create.
-     The time interval to create the image is 1000 milli second.
-     See setFrameTimeBetweenImages to change the time interval.
-     
-     - Parameter frameNumberOfImages: The number of images to create.
-     */
-    @objc
-    public func setFrameNumberOfImages(frameNumberOfImages: Int) {
-        if frameNumberOfImages < 0 {
-            self.cameraEventListener?.onError(error: KeyError.INVALID_FRAME_NUMBER_OF_IMAGES.rawValue)
-            return
-        }
         
-        self.captureOptions.frameNumberOfImages = frameNumberOfImages
-    }
-    
-    /**
-     Set saving frame images time interval in milli seconds.
-     
-     - Parameter frameTimeBetweenImages: The time in milli seconds. Default value is `1000`.
-     */
-    @objc
-    public func setFrameTimeBetweenImages(frameTimeBetweenImages: Int64) {
-        if frameTimeBetweenImages < 0 {
-            self.cameraEventListener?.onError(error: KeyError.INVALID_FRAME_TIME_BETWEEN_IMAGES.rawValue)
-            return
-        }
-        
-        self.captureOptions.frameTimeBetweenImages = frameTimeBetweenImages
-    }
-    
     /**
      Set to apply enable/disable face region of interest.
      

--- a/YoonitCamera/src/CameraView.swift
+++ b/YoonitCamera/src/CameraView.swift
@@ -57,7 +57,7 @@ public class CameraView: UIView {
     }
     
     private func configure() {
-                
+        
         self.layer.addSublayer(self.previewLayer)
         
         self.session.sessionPreset = .hd1280x720
@@ -71,7 +71,7 @@ public class CameraView: UIView {
             session: self.session,
             previewLayer: self.previewLayer)
     }
-        
+    
     /**
      Start camera preview if has permission.
      */
@@ -84,8 +84,8 @@ public class CameraView: UIView {
      Start capture type: none, face, barcode or frame.
      Must have started preview, see `startPreview`.
      
-     - Parameters: `"none"` | `"face"` | `"barcode"` | `"frame"`.
-     - Precondition: value string must be one of `"none"`, `"face"`, `"barcode"`, `"frame"` and must have started preview.
+     - Parameters: `"none"` | `"face"` | `"qrcode"` | `"frame"`.
+     - Precondition: value string must be one of `"none"`, `"face"`, `"qrcode"`, `"frame"` and must have started preview.
      */
     @objc
     public func startCaptureType(captureType: String) {
@@ -103,9 +103,7 @@ public class CameraView: UIView {
             self.cameraController?.startCaptureType(captureType: CaptureType.FRAME)
             
         default:
-            if (self.cameraEventListener != nil) {
-                self.cameraEventListener?.onError(error: KeyError.INVALID_CAPTURE_TYPE.rawValue)
-            }
+            fatalError(KeyError.INVALID_CAPTURE_TYPE.rawValue)
         }
     }
     
@@ -115,7 +113,7 @@ public class CameraView: UIView {
     @objc
     public func stopCapture() {
         self.cameraController?.stopAnalyzer()
-    }            
+    }
     
     /**
      Toggle between Front and Back Camera.
@@ -128,7 +126,8 @@ public class CameraView: UIView {
     /**
      Get current camera lens.
      
-     - Returns: value 0 is front camera; value 1 is back camera.
+     - Returns: value 0 is front camera.
+     Default value 1 is back camera.
      */
     @objc
     public func getCameraLens() -> Int {
@@ -139,12 +138,12 @@ public class CameraView: UIView {
      Set number of face/frame file images to create.
      
      - Parameter numberOfImages: The number of images to create.
+     Default value is 0.
      */
     @objc
     public func setNumberOfImages(numberOfImages: Int) {
         if numberOfImages < 0 {
-            self.cameraEventListener?.onError(error: KeyError.INVALID_NUMBER_OF_IMAGES.rawValue)
-            return
+            fatalError(KeyError.INVALID_NUMBER_OF_IMAGES.rawValue)
         }
         
         self.captureOptions.numberOfImages = numberOfImages
@@ -153,82 +152,86 @@ public class CameraView: UIView {
     /**
      Set saving face/frame images time interval in milli seconds.
      
-     - Parameter faceTimeBetweenImages: The time in milli seconds. Default value is `1000`.
+     - Parameter faceTimeBetweenImages: The time in milli seconds.
+     Default value is `1000`.
      */
     @objc
     public func setTimeBetweenImages(timeBetweenImages: Int64) {
         if timeBetweenImages < 0 {
-            self.cameraEventListener?.onError(error: KeyError.INVALID_TIME_BETWEEN_IMAGES.rawValue)
-            return
+            fatalError(KeyError.INVALID_TIME_BETWEEN_IMAGES.rawValue)
         }
         
         self.captureOptions.timeBetweenImages = timeBetweenImages
     }
     
     /**
-      Set face image width to be created.
+     Set face image width to be created.
      
-     - Parameter width: The file image width in pixels. Default value is 200.
+     - Parameter width: The file image width in pixels.
+     Default value is `200`.
      */
     @objc
     public func setOutputImageWidth(width: Int) {
         if (width <= 0) {
             fatalError(KeyError.INVALID_OUTPUT_IMAGE_WIDTH.rawValue)
         }
-
+        
         self.captureOptions.imageOutputWidth = width
     }
-
+    
     /**
-      Set face image height to be created.
+     Set face image height to be created.
      
-     - Parameter height: The file image height in pixels. Default value is 200.
+     - Parameter height: The file image height in pixels.
+     Default value is `200`.
      */
     @objc
     public func setOutputImageHeight(height: Int) {
         if (height <= 0) {
             fatalError(KeyError.INVALID_OUTPUT_IMAGE_HEIGHT.rawValue)
         }
-
+        
         self.captureOptions.imageOutputHeight = height
+    }
+    
+    /**
+     Set to enable/disable save images when capturing face/frame.
+     
+     - Parameter enable: The indicator to enable or disable the face/frame save images.
+     Default value is `false`.
+     */
+    @objc
+    public func setSaveImageCaptured(enable: Bool) {
+        self.captureOptions.saveImageCaptured = enable
     }
     
     /**
      Set to show/hide face detection box when face detected.
      The detection box is the detected face bounding box draw.
      
-     - Parameter faceDetectionBox: The indicator to show or hide the face detection box. Default value is `true`.
+     - Parameter enable: The indicator to show or hide the face detection box.
+     Default value is `true`.
      */
     @objc
-    public func setFaceDetectionBox(faceDetectionBox: Bool) {
-        self.captureOptions.faceDetectionBox = faceDetectionBox
+    public func setFaceDetectionBox(enable: Bool) {
+        self.captureOptions.faceDetectionBox = enable
     }
     
     /**
-     Set to enable/disable face save images when capturing faces.
-     
-     - Parameter faceSaveImages: The indicator to enable or disable the face save images. Default value is `false`.
-     */
-    @objc
-    public func setFaceSaveImages(faceSaveImages: Bool) {
-        self.captureOptions.faceSaveImages = faceSaveImages
-    }
-        
-    /**
      Enlarge the face bounding box by percent.
      
-     - Parameter facePaddingPercent: The percent to enlarge the bounding box. Default value is `0.27`.
+     - Parameter facePaddingPercent: The percent to enlarge the bounding box.
+     Default value is `0.27`.
      */
     @objc
     public func setFacePaddingPercent(facePaddingPercent: Float) {
         if facePaddingPercent < 0 {
-            self.cameraEventListener?.onError(error: KeyError.INVALID_FACE_PADDING_PERCENT.rawValue)
-            return
+            fatalError(KeyError.INVALID_FACE_PADDING_PERCENT.rawValue)
         }
         
         self.captureOptions.facePaddingPercent = facePaddingPercent
     }
-        
+    
     /**
      Limit the minimum face capture size.
      This variable is the face detection box percentage in relation with the UI graphic view.
@@ -237,13 +240,13 @@ public class CameraView: UIView {
      For example, if set 0.5, will capture face with the detection box width occupying
      at least 50% of the screen width.
      
-     - Parameter faceCaptureMinSize The face capture min size value. Default value is 0,
+     - Parameter faceCaptureMinSize The face capture min size value.
+     Default value is `0`,
      */
     @objc
     public func setFaceCaptureMinSize(faceCaptureMinSize: Float) {
         if faceCaptureMinSize < 0.0 || faceCaptureMinSize > 1.0 {
-            self.cameraEventListener?.onError(error: KeyError.INVALID_FACE_CAPTURE_MIN_SIZE.rawValue)
-            return
+            fatalError(KeyError.INVALID_FACE_CAPTURE_MIN_SIZE.rawValue)
         }
         
         self.captureOptions.faceCaptureMinSize = faceCaptureMinSize
@@ -257,26 +260,27 @@ public class CameraView: UIView {
      For example, if set 0.7, will capture face with the detection box width occupying
      at least 70% of the screen width.
      
-     - Parameter faceCaptureMaxSize The face capture max size value. Default value is 1.0.
+     - Parameter faceCaptureMaxSize The face capture max size value.
+     Default value is `1.0`.
      */
     @objc
     public func setFaceCaptureMaxSize(faceCaptureMaxSize: Float) {
         if faceCaptureMaxSize < 0.0 || faceCaptureMaxSize > 1.0 {
-            self.cameraEventListener?.onError(error: KeyError.INVALID_FACE_CAPTURE_MAX_SIZE.rawValue)
-            return
+            fatalError(KeyError.INVALID_FACE_CAPTURE_MAX_SIZE.rawValue)
         }
         
         self.captureOptions.faceCaptureMaxSize = faceCaptureMaxSize
     }
-        
+    
     /**
      Set to apply enable/disable face region of interest.
      
-     - Parameter faceROIEnable: The indicator to enable/disable face region of interest. Default value is `false`.
+     - Parameter enable: The indicator to enable/disable face region of interest.
+     Default value is `false`.
      */
     @objc
-    public func setFaceROIEnable(faceROIEnable: Bool) {
-        self.captureOptions.faceROI.enable = faceROIEnable
+    public func setFaceROIEnable(enable: Bool) {
+        self.captureOptions.faceROI.enable = enable
     }
     
     /**
@@ -301,10 +305,9 @@ public class CameraView: UIView {
             leftOffset < 0.0 || leftOffset > 1.0
         
         if isInvalid {
-            self.cameraEventListener?.onError(error: KeyError.INVALID_FACE_ROI_OFFSET.rawValue)
-            return
+            fatalError(KeyError.INVALID_FACE_ROI_OFFSET.rawValue)
         }
-    
+        
         self.captureOptions.faceROI.topOffset = topOffset
         self.captureOptions.faceROI.rightOffset = rightOffset
         self.captureOptions.faceROI.bottomOffset = bottomOffset
@@ -314,15 +317,16 @@ public class CameraView: UIView {
     /**
      Set face minimum size in relation of the region of interest.
      
-     - Parameter minimumSize: Represents in percentage [0, 1]. Default value is `0`.
+     - Parameter minimumSize: Represents in percentage [0, 1].
+     Default value is `0`.
      */
     @objc
     public func setFaceROIMinSize(minimumSize: Float) {
         if minimumSize < 0.0 || minimumSize > 1.0 {
-            self.cameraEventListener?.onError(error: KeyError.INVALID_FACE_ROI_MIN_SIZE.rawValue)
-            return
+            fatalError(KeyError.INVALID_FACE_ROI_MIN_SIZE.rawValue)
         }
         
         self.captureOptions.faceROI.minimumSize = minimumSize
     }
 }
+

--- a/YoonitCamera/src/CameraView.swift
+++ b/YoonitCamera/src/CameraView.swift
@@ -166,6 +166,34 @@ public class CameraView: UIView {
     }
     
     /**
+      Set face image width to be created.
+     
+     - Parameter width: The file image width in pixels. Default value is 200.
+     */
+    @objc
+    public func setOutputImageWidth(width: Int) {
+        if (width <= 0) {
+            fatalError(KeyError.INVALID_OUTPUT_IMAGE_WIDTH.rawValue)
+        }
+
+        self.captureOptions.imageOutputWidth = width
+    }
+
+    /**
+      Set face image height to be created.
+     
+     - Parameter height: The file image height in pixels. Default value is 200.
+     */
+    @objc
+    public func setOutputImageHeight(height: Int) {
+        if (height <= 0) {
+            fatalError(KeyError.INVALID_OUTPUT_IMAGE_HEIGHT.rawValue)
+        }
+
+        self.captureOptions.imageOutputHeight = height
+    }
+    
+    /**
      Set to show/hide face detection box when face detected.
      The detection box is the detected face bounding box draw.
      
@@ -200,24 +228,7 @@ public class CameraView: UIView {
         
         self.captureOptions.facePaddingPercent = facePaddingPercent
     }
-    
-    /**
-     Set face image width and height to be saved.
-     
-     - Parameter width: The face image width saved in pixel. Default value is `200`.
-     - Parameter height: The face image height saved in pixel. Default value is `200`.
-     - Precondition: `width` and `height` must be greater than 0.
-     */
-    @objc
-    public func setFaceImageSize(width: Int, height: Int) {
-        if width <= 0 || height <= 0 {
-            self.cameraEventListener?.onError(error: KeyError.INVALID_FACE_IMAGE_SIZE.rawValue)
-            return
-        }
         
-        self.captureOptions.faceImageSize = CGSize(width: width, height: height)
-    }
-    
     /**
      Limit the minimum face capture size.
      This variable is the face detection box percentage in relation with the UI graphic view.

--- a/YoonitCamera/src/CaptureType.swift
+++ b/YoonitCamera/src/CaptureType.swift
@@ -16,6 +16,6 @@ import Foundation
 public enum CaptureType: Int {
     case NONE = 0
     case FACE = 1
-    case BARCODE = 2
+    case QRCODE = 2
     case FRAME = 3
 }

--- a/YoonitCamera/src/KeyError.swift
+++ b/YoonitCamera/src/KeyError.swift
@@ -20,11 +20,11 @@ public enum KeyError: String {
     // Tried to start a non-existent capture type.
     case INVALID_CAPTURE_TYPE = "INVALID_CAPTURE_TYPE"
     
-    // Tried to input invalid face number of images to capture.
-    case INVALID_FACE_NUMBER_OF_IMAGES = "INVALID_FACE_NUMBER_OF_IMAGES"
+    // Tried to input invalid face/frame number of images to capture.
+    case INVALID_NUMBER_OF_IMAGES = "INVALID_NUMBER_OF_IMAGES"
     
-    // Tried to input invalid face time interval to capture face.
-    case INVALID_FACE_TIME_BETWEEN_IMAGES = "INVALID_FACE_TIME_BETWEEN_IMAGES"
+    // Tried to input invalid face/frame time interval to capture.
+    case INVALID_TIME_BETWEEN_IMAGES = "INVALID_TIME_BETWEEN_IMAGES"
     
     // Tried to input invalid face padding percent.
     case INVALID_FACE_PADDING_PERCENT = "INVALID_FACE_PADDING_PERCENT"

--- a/YoonitCamera/src/KeyError.swift
+++ b/YoonitCamera/src/KeyError.swift
@@ -26,24 +26,21 @@ public enum KeyError: String {
     // Tried to input invalid face/frame time interval to capture.
     case INVALID_TIME_BETWEEN_IMAGES = "INVALID_TIME_BETWEEN_IMAGES"
     
+    // Tried to input invalid image width.
+    case INVALID_OUTPUT_IMAGE_WIDTH = "INVALID_OUTPUT_IMAGE_WIDTH"
+
+    // Tried to input invalid image height.
+    case INVALID_OUTPUT_IMAGE_HEIGHT = "INVALID_OUTPUT_IMAGE_HEIGHT"
+    
     // Tried to input invalid face padding percent.
     case INVALID_FACE_PADDING_PERCENT = "INVALID_FACE_PADDING_PERCENT"
-    
-    // Tried to input invalid image width or height.
-    case INVALID_FACE_IMAGE_SIZE = "INVALID_FACE_IMAGE_SIZE"
-    
+        
     // Tried to input invalid face capture minimum size.
     case INVALID_FACE_CAPTURE_MIN_SIZE = "INVALID_FACE_CAPTURE_MIN_SIZE"
     
     // Tried to input invalid face capture maximum size.
     case INVALID_FACE_CAPTURE_MAX_SIZE = "INVALID_FACE_CAPTURE_MAX_SIZE"
-    
-    // Tried to input invalid frame number of images to capture.
-    case INVALID_FRAME_NUMBER_OF_IMAGES = "INVALID_FRAME_NUMBER_OF_IMAGES"
-    
-    // Tried to input invalid frame time interval to capture face.
-    case INVALID_FRAME_TIME_BETWEEN_IMAGES = "INVALID_FRAME_TIME_BETWEEN_IMAGES"
-    
+        
     // Tried to input invalid face region of interesting offset.
     case INVALID_FACE_ROI_OFFSET = "INVALID_FACE_ROI_OFFSET"
     

--- a/YoonitCamera/src/analyzers/face/FaceAnalyzer.swift
+++ b/YoonitCamera/src/analyzers/face/FaceAnalyzer.swift
@@ -184,7 +184,7 @@ class FaceAnalyzer: NSObject {
             width: Int(detectionBox!.width),
             height: Int(detectionBox!.height))
         
-        if !self.captureOptions.faceSaveImages {
+        if !self.captureOptions.saveImageCaptured {
             return
         }
         

--- a/YoonitCamera/src/analyzers/face/FaceAnalyzer.swift
+++ b/YoonitCamera/src/analyzers/face/FaceAnalyzer.swift
@@ -230,7 +230,7 @@ class FaceAnalyzer: NSObject {
         if (self.captureOptions.numberOfImages > 0) {
             if (self.numberOfImages < self.captureOptions.numberOfImages) {
                 self.numberOfImages += 1
-                self.cameraEventListener?.onImageCreated(
+                self.cameraEventListener?.onImageCaptured(
                     type: "face",
                     count: self.numberOfImages,
                     total: self.captureOptions.numberOfImages,
@@ -246,7 +246,7 @@ class FaceAnalyzer: NSObject {
         
         // process face unlimited.
         self.numberOfImages = (self.numberOfImages + 1) % MAX_NUMBER_OF_IMAGES
-        self.cameraEventListener?.onImageCreated(
+        self.cameraEventListener?.onImageCaptured(
             type: "face",
             count: self.numberOfImages,
             total: self.captureOptions.numberOfImages,

--- a/YoonitCamera/src/analyzers/face/FaceAnalyzer.swift
+++ b/YoonitCamera/src/analyzers/face/FaceAnalyzer.swift
@@ -204,10 +204,15 @@ class FaceAnalyzer: NSObject {
                 // Result of the crop face process.
                 result in
                 
+                let imageResized = try! result.resize(
+                    width: self.captureOptions.imageOutputWidth,
+                    height: self.captureOptions.imageOutputHeight)
+                
                 let fileURL = fileURLFor(index: self.numberOfImages)
-                let fileName = try! save(image: result, at: fileURL)
-                
-                
+                let fileName = try! save(
+                    image: imageResized,
+                    fileURL: fileURL)
+                                
                 // Emit the face image file path.
                 self.handleEmitImageCaptured(filePath: fileName)
             }

--- a/YoonitCamera/src/analyzers/face/FaceAnalyzer.swift
+++ b/YoonitCamera/src/analyzers/face/FaceAnalyzer.swift
@@ -35,7 +35,7 @@ class FaceAnalyzer: NSObject {
     private var faceBoundingBoxController: FaceBoundingBoxController
     private var lastTimestamp = Date().currentTimeMillis()
     private var shouldDraw = true
-    private var isValid = false
+    private var isValid = true
     public var numberOfImages = 0
     
     public var drawings: [CAShapeLayer] = [] {

--- a/YoonitCamera/src/analyzers/face/FaceAnalyzer.swift
+++ b/YoonitCamera/src/analyzers/face/FaceAnalyzer.swift
@@ -192,7 +192,7 @@ class FaceAnalyzer: NSObject {
         let currentTimestamp = Date().currentTimeMillis()
         let diffTime = currentTimestamp - self.lastTimestamp
         
-        if diffTime > self.captureOptions.faceTimeBetweenImages {
+        if diffTime > self.captureOptions.timeBetweenImages {
             self.lastTimestamp = currentTimestamp
         
             // Crop the face image.
@@ -222,12 +222,13 @@ class FaceAnalyzer: NSObject {
     public func handleEmitImageCaptured(filePath: String) {
         
         // process face number of images.
-        if (self.captureOptions.faceNumberOfImages > 0) {
-            if (self.numberOfImages < self.captureOptions.faceNumberOfImages) {
+        if (self.captureOptions.numberOfImages > 0) {
+            if (self.numberOfImages < self.captureOptions.numberOfImages) {
                 self.numberOfImages += 1
-                self.cameraEventListener?.onFaceImageCreated(
+                self.cameraEventListener?.onImageCreated(
+                    type: "face",
                     count: self.numberOfImages,
-                    total: self.captureOptions.faceNumberOfImages,
+                    total: self.captureOptions.numberOfImages,
                     imagePath: filePath
                 )
                 return
@@ -240,9 +241,10 @@ class FaceAnalyzer: NSObject {
         
         // process face unlimited.
         self.numberOfImages = (self.numberOfImages + 1) % MAX_NUMBER_OF_IMAGES
-        self.cameraEventListener?.onFaceImageCreated(
+        self.cameraEventListener?.onImageCreated(
+            type: "face",
             count: self.numberOfImages,
-            total: self.captureOptions.faceNumberOfImages,
+            total: self.captureOptions.numberOfImages,
             imagePath: filePath
         )
     }

--- a/YoonitCamera/src/analyzers/frame/FrameAnalyzer.swift
+++ b/YoonitCamera/src/analyzers/frame/FrameAnalyzer.swift
@@ -56,6 +56,10 @@ class FrameAnalyzer: NSObject {
             self.lastTimestamp = currentTimestamp
             
             DispatchQueue.main.async {
+                if (!self.captureOptions.saveImageCaptured) {
+                    return
+                }
+                
                 let orientation = self.captureOptions.cameraLens.rawValue == 1 ?
                     UIImage.Orientation.up : UIImage.Orientation.upMirrored
                 

--- a/YoonitCamera/src/analyzers/frame/FrameAnalyzer.swift
+++ b/YoonitCamera/src/analyzers/frame/FrameAnalyzer.swift
@@ -52,7 +52,7 @@ class FrameAnalyzer: NSObject {
         let currentTimestamp = Date().currentTimeMillis()
         let diffTime = currentTimestamp - self.lastTimestamp
         
-        if diffTime > self.captureOptions.frameTimeBetweenImages {
+        if diffTime > self.captureOptions.timeBetweenImages {
             self.lastTimestamp = currentTimestamp
             
             DispatchQueue.main.async {
@@ -70,12 +70,13 @@ class FrameAnalyzer: NSObject {
         let fileURL = fileURLFor(index: self.numberOfImages)
         let filePath = try! save(image: image, at: fileURL)
         
-        if (self.captureOptions.frameNumberOfImages > 0) {
-            if (self.numberOfImages < self.captureOptions.frameNumberOfImages) {
+        if (self.captureOptions.numberOfImages > 0) {
+            if (self.numberOfImages < self.captureOptions.numberOfImages) {
                 self.numberOfImages += 1
-                self.cameraEventListener?.onFrameImageCreated(
+                self.cameraEventListener?.onImageCreated(
+                    type: "frame",
                     count: self.numberOfImages,
-                    total: self.captureOptions.frameNumberOfImages,
+                    total: self.captureOptions.numberOfImages,
                     imagePath: filePath
                 )
                 return
@@ -87,9 +88,10 @@ class FrameAnalyzer: NSObject {
         }
         
         self.numberOfImages = (self.numberOfImages + 1) % MAX_NUMBER_OF_IMAGES
-        self.cameraEventListener?.onFrameImageCreated(
+        self.cameraEventListener?.onImageCreated(
+            type: "frame",
             count: self.numberOfImages,
-            total: self.captureOptions.frameNumberOfImages,
+            total: self.captureOptions.numberOfImages,
             imagePath: filePath
         )
     }

--- a/YoonitCamera/src/analyzers/frame/FrameAnalyzer.swift
+++ b/YoonitCamera/src/analyzers/frame/FrameAnalyzer.swift
@@ -89,7 +89,7 @@ class FrameAnalyzer: NSObject {
         if (self.captureOptions.numberOfImages > 0) {
             if (self.numberOfImages < self.captureOptions.numberOfImages) {
                 self.numberOfImages += 1
-                self.cameraEventListener?.onImageCreated(
+                self.cameraEventListener?.onImageCaptured(
                     type: "frame",
                     count: self.numberOfImages,
                     total: self.captureOptions.numberOfImages,
@@ -105,7 +105,7 @@ class FrameAnalyzer: NSObject {
         
         // process frame unlimited.
         self.numberOfImages = (self.numberOfImages + 1) % MAX_NUMBER_OF_IMAGES
-        self.cameraEventListener?.onImageCreated(
+        self.cameraEventListener?.onImageCaptured(
             type: "frame",
             count: self.numberOfImages,
             total: self.captureOptions.numberOfImages,

--- a/YoonitCamera/src/delegates/CameraEventListenerDelegate.swift
+++ b/YoonitCamera/src/delegates/CameraEventListenerDelegate.swift
@@ -15,7 +15,8 @@ import Foundation
 @objc
 public protocol CameraEventListenerDelegate {
 
-    func onFaceImageCreated(
+    func onImageCreated(
+        type: String,
         count: Int,
         total: Int,
         imagePath: String)
@@ -36,10 +37,5 @@ public protocol CameraEventListenerDelegate {
 
     func onPermissionDenied()
 
-    func onBarcodeScanned(content: String)
-    
-    func onFrameImageCreated(
-        count: Int,
-        total: Int,
-        imagePath: String)
+    func onQRCodeScanned(content: String)
 }

--- a/YoonitCamera/src/delegates/CameraEventListenerDelegate.swift
+++ b/YoonitCamera/src/delegates/CameraEventListenerDelegate.swift
@@ -15,7 +15,7 @@ import Foundation
 @objc
 public protocol CameraEventListenerDelegate {
 
-    func onImageCreated(
+    func onImageCaptured(
         type: String,
         count: Int,
         total: Int,

--- a/YoonitCamera/src/models/CaptureOptions.swift
+++ b/YoonitCamera/src/models/CaptureOptions.swift
@@ -33,6 +33,12 @@ public class CaptureOptions {
     // Face/Frame capture time between images in milliseconds.
     var timeBetweenImages: Int64 = 1000
         
+    // Face/Frame capture image width to create.
+    var imageOutputWidth: Int = 200
+
+    // Face/Frame capture image height to create.
+    var imageOutputHeight: Int = 200
+    
     // Draw or not the face detection box.
     var faceDetectionBox: Bool = true
     
@@ -41,10 +47,7 @@ public class CaptureOptions {
         
     // Face capture padding percent.
     var facePaddingPercent: Float = 0.27
-    
-    // Face capture image size to save.
-    var faceImageSize = CGSize(width: 200, height: 200)
-    
+        
     /**
      Face capture min size.
      This variable is the face detection box percentage in relation with the UI graphic view.

--- a/YoonitCamera/src/models/CaptureOptions.swift
+++ b/YoonitCamera/src/models/CaptureOptions.swift
@@ -27,18 +27,18 @@ public class CaptureOptions {
     // Camera lens facing: CameraSelector.LENS_FACING_FRONT and CameraSelector.LENS_FACING_BACK.
     var cameraLens: AVCaptureDevice.Position = AVCaptureDevice.Position.front
     
+    // Face/Frame capture number of images. 0 capture unlimited.
+    var numberOfImages: Int = 0
+
+    // Face/Frame capture time between images in milliseconds.
+    var timeBetweenImages: Int64 = 1000
+        
     // Draw or not the face detection box.
     var faceDetectionBox: Bool = true
     
     // Face save cropped images.
     var faceSaveImages: Bool = false
-    
-    // Face capture number of images. 0 capture unlimited.
-    var faceNumberOfImages: Int = 0
-    
-    // Face capture time between images in milliseconds.
-    var faceTimeBetweenImages: Int64 = 1000
-    
+        
     // Face capture padding percent.
     var facePaddingPercent: Float = 0.27
     
@@ -58,10 +58,4 @@ public class CaptureOptions {
      The value must be between 0 and 1.   
      */
     var faceCaptureMaxSize: Float = 1.0
-    
-    // Frame capture number of images. 0 capture unlimited.
-    var frameNumberOfImages: Int = 0
-    
-    // Frame capture time between images in milliseconds.
-    var frameTimeBetweenImages: Int64 = 1000
 }

--- a/YoonitCamera/src/models/CaptureOptions.swift
+++ b/YoonitCamera/src/models/CaptureOptions.swift
@@ -39,12 +39,12 @@ public class CaptureOptions {
     // Face/Frame capture image height to create.
     var imageOutputHeight: Int = 200
     
+    // Face/Frame save images captured.
+    var saveImageCaptured: Bool = false
+    
     // Draw or not the face detection box.
     var faceDetectionBox: Bool = true
-    
-    // Face save cropped images.
-    var faceSaveImages: Bool = false
-        
+            
     // Face capture padding percent.
     var facePaddingPercent: Float = 0.27
         

--- a/YoonitCamera/src/utils/FileUtils.swift
+++ b/YoonitCamera/src/utils/FileUtils.swift
@@ -26,7 +26,7 @@ func fileURLFor(index: Int) -> URL {
     return tempDirectory.appendingPathComponent(String(format: "yoonit-%04d.jpg", index))
 }
 
-func save(image: UIImage, at fileURL: URL) throws -> String {
+func save(image: UIImage, fileURL: URL) throws -> String {            
     let data = image.jpegData(compressionQuality: 1)
     
     if (data == nil) {

--- a/YoonitCamera/src/utils/FileUtils.swift
+++ b/YoonitCamera/src/utils/FileUtils.swift
@@ -13,43 +13,32 @@
 import Foundation
 import UIKit
 
-
-let IMAGE_DIR = "facetrack"
-
 enum FileUtilsError: Error {
     case invalidJPEGData
 }
 
 func fileURLFor(index: Int) -> URL {
-    let tempDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-    return tempDirectory.appendingPathComponent(String(format: "facetrack-%04d.jpg", index))
+    let tempDirectory = FileManager
+        .default
+        .urls(for: .documentDirectory, in: .userDomainMask)
+        .first!
+    
+    return tempDirectory.appendingPathComponent(String(format: "yoonit-%04d.jpg", index))
 }
 
-func save(image: UIImage, at fileURL: URL) throws -> String{
+func save(image: UIImage, at fileURL: URL) throws -> String {
     let data = image.jpegData(compressionQuality: 1)
-
+    
     if (data == nil) {
         throw FileUtilsError.invalidJPEGData
     }
-    //Checks if file exists, removes it if so.
+    
     if FileManager.default.fileExists(atPath: fileURL.path) {
         try FileManager.default.removeItem(atPath: fileURL.path)
     }
-
+    
     try data!.write(to: fileURL)
-
+    
     return fileURL.standardizedFileURL.absoluteString
-}
-
-func clearCapturedImages() {
-    let fileManager = FileManager.default
-    let tempDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-
-    let items = try? fileManager.contentsOfDirectory(at: tempDirectory, includingPropertiesForKeys: nil)
-    items?.forEach { item in
-        if item.absoluteString.contains("keyface"){
-            try? fileManager.removeItem(at: item)
-        }
-    }
 }
 

--- a/YoonitCamera/src/utils/extensions.swift
+++ b/YoonitCamera/src/utils/extensions.swift
@@ -36,13 +36,20 @@ extension CGRect {
 }
 
 extension UIImage {
-    func resized(to newSize: CGSize) throws -> UIImage {
-        UIGraphicsBeginImageContext(newSize)
-        self.draw(in: CGRect(x: 0, y: 0,
-                              width: newSize.width,
-                              height: newSize.height))
+    
+    func resize(width: Int, height: Int) throws -> UIImage {
+        UIGraphicsBeginImageContext(CGSize(width: width, height: height))
+        
+        let newSize = CGRect(
+            x: 0,
+            y: 0,
+            width: width,
+            height: height)
+        
+        self.draw(in: newSize)
 
         let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        
         UIGraphicsEndImageContext()
         return newImage!
     }


### PR DESCRIPTION
## :boom: Breaking Changes

Unify methods `setFaceNumberOfImages` and `setFrameNumberOfImages` into `setNumberOfImages`:
- Changed for better understanding and usage simplification;
- The number of images is used to capture face and frame;
- The number of images value "0" still capture unlimited number of images;
- Add validation: the number of images value can not be negative;

</br>

Unify methods `setFaceTimeBetweenImages` and `setFrameTimeBetweenImages` into `setTimeBetweenImages`;
- Changed for better understanding and usage simplification;
- The time between of images is used to capture face and frame;
- The time between of images value is still in milliseconds;
- Add validation: the time between of images value can not be negative;

</br>

Split methods `setFaceImageSize` in `setOutputImageWidth` and `setOutputImageHeight`;
- Changed for better understanding;
- Add validation: the output image width value can not be negative;
- Add validation: the output image height value can not be negative;

</br>

Unify events `onFaceImageCreated` and `onFrameImageCreated` into `onImageCaptured`;
- Changed for better understanding and usage simplification;
- The number of images is used to capture face and frame;
- The event is used when a face or frame image is saved;


## :zap: Improvements

Emit `onFaceUndetected` when started capture type face and no face is detected.
Last version, when started capture face and no face is detected, no event was emitted.


## :goal_net: Catch Errors

Add validation when inputing value in the following methods.
Valid values for each method described in the `KeyError` section of the `README`.

- `startCaptureType`: Valid values "none", "face", "frame" and "qrcode";
- `setNumberOfImages`: Value can not be negative;
- `setTimeBetweenImages`: Value can not be negative;
- `setOutputImageWidth`: Value can not be negative;
- `setOutputImageHeight`: Value can not be negative;
- `setFacePaddingPercent`: Value must be between 0 and 1;
- `setFaceCaptureMinSize`: Value must be between 0 and 1;
- `setFaceCaptureMaxSize`: Value must be between 0 and 1;
- `setFaceROIOffset`: Values must be between 0 and 1;
- `setFaceROIMinSize`: Value must be between 0 and 1;


## :recycle: Refactor

- Change event from `onBarcodeScanned` to `onQRCodeScanned`;
- Change method from `setFaceSaveImages` to `setSaveImageCaptured`;
- Change method `startCaptureType` for input "barcode" to "qrcode";
- Change all internal text/file from "barcode" to "qrcode"; 



## :memo: Update Readme

- Add method `setNumberOfImages` definition;
- Add method `setTimeBetweenImages` definition;
- Add method `setOutputImageHeight` definition;
- Add method `onImageCaptured` definition;
- Add event `onQRCodeScanned` definition;
- Update `KeyError` section;