### PR TITLE
Change the class CaptureOptions to a singleton

### DIFF
--- a/Example/YoonitCameraDemo/YoonitCameraDemo/Base.lproj/Main.storyboard
+++ b/Example/YoonitCameraDemo/YoonitCameraDemo/Base.lproj/Main.storyboard
@@ -116,6 +116,8 @@
                     <connections>
                         <outlet property="cameraTypeDropDown" destination="NTX-Bi-sU8" id="rh9-fq-g8S"/>
                         <outlet property="cameraView" destination="s7c-6p-oqC" id="tUf-Wq-rUD"/>
+                        <outlet property="faceDetectionBoxSwitch" destination="07t-4a-cSE" id="3YP-fx-Kkq"/>
+                        <outlet property="imageCaptureSwitch" destination="0Nd-tg-26L" id="eQe-0L-E13"/>
                         <outlet property="qrCodeTextField" destination="v8g-XX-tYC" id="ODX-Wv-8me"/>
                         <outlet property="savedFrame" destination="cye-Bx-CYr" id="fa9-d9-e9O"/>
                     </connections>

--- a/Example/YoonitCameraDemo/YoonitCameraDemo/CameraViewController.swift
+++ b/Example/YoonitCameraDemo/YoonitCameraDemo/CameraViewController.swift
@@ -19,6 +19,8 @@ class CameraViewController: UIViewController {
     @IBOutlet var cameraView: CameraView!
     @IBOutlet var cameraTypeDropDown: UIButton!
     @IBOutlet var qrCodeTextField: UITextField!
+    @IBOutlet var faceDetectionBoxSwitch: UISwitch!
+    @IBOutlet var imageCaptureSwitch: UISwitch!
     
     var showImagePreview = false
     
@@ -156,6 +158,10 @@ class CameraViewController: UIViewController {
             self.cameraView.startPreview()
         } else {
             self.cameraView.destroy()
+            self.clearFaceImagePreview()
+            self.captureType = "none"
+            self.faceDetectionBoxSwitch.isOn = false
+            self.imageCaptureSwitch.isOn = false
         }
     }
     

--- a/YoonitCamera/src/CameraController.swift
+++ b/YoonitCamera/src/CameraController.swift
@@ -21,10 +21,7 @@ class CameraController: NSObject {
     
     // Reference to camera view used to draw bounding box.
     private var cameraView: CameraView!
-    
-    // Model to set CameraView features options.
-    public var captureOptions: CaptureOptions!
-        
+                
     // Manages multiple inputs and outputs of audio and video.
     private var session: AVCaptureSession
     private var previewLayer: AVCaptureVideoPreviewLayer
@@ -44,22 +41,19 @@ class CameraController: NSObject {
     
     init(
         cameraView: CameraView,
-        captureOptions: CaptureOptions,
         session: AVCaptureSession,
         previewLayer: AVCaptureVideoPreviewLayer) {
         
         self.session = session
         self.previewLayer = previewLayer
-                    
         self.cameraView = cameraView
-        self.captureOptions = captureOptions
         
         self.faceAnalyzer = FaceAnalyzer(
-            captureOptions: self.captureOptions,
             cameraView: self.cameraView,
-            previewLayer: self.previewLayer)
+            previewLayer: self.previewLayer
+        )
         
-        self.frameAnalyzer = FrameAnalyzer(captureOptions: self.captureOptions)
+        self.frameAnalyzer = FrameAnalyzer()
     }
     
     required init?(coder: NSCoder) {
@@ -84,7 +78,7 @@ class CameraController: NSObject {
         }
                         
         // Build camera input based on the camera lens.
-        self.buildCameraInput(cameraLens: self.captureOptions.cameraLens)        
+        self.buildCameraInput(cameraLens: captureOptions.cameraLens)
                 
         // Start running the session.
         self.session.startRunning()
@@ -115,10 +109,10 @@ class CameraController: NSObject {
      */
     public func startCaptureType(captureType: CaptureType) {
                         
-        self.captureOptions.type = captureType
+        captureOptions.type = captureType
         self.stopAnalyzer()
         
-        switch self.captureOptions.type {
+        switch captureOptions.type {
         case CaptureType.FACE:
             self.faceAnalyzer?.start()
             
@@ -145,10 +139,10 @@ class CameraController: NSObject {
      Toggle between Front and Back Camera.
      */
     public func toggleCameraLens() {
-        if (self.captureOptions.cameraLens == .front) {
-            self.captureOptions.cameraLens = .back
+        if (captureOptions.cameraLens == .front) {
+            captureOptions.cameraLens = .back
         } else {
-            self.captureOptions.cameraLens = .front
+            captureOptions.cameraLens = .front
         }
         
         if self.session.isRunning {
@@ -158,9 +152,9 @@ class CameraController: NSObject {
             self.session.outputs.forEach({ self.session.removeOutput($0) })
             
             // Add camera input.
-            self.buildCameraInput(cameraLens: self.captureOptions.cameraLens)
+            self.buildCameraInput(cameraLens: captureOptions.cameraLens)
                                     
-            switch self.captureOptions.type {
+            switch captureOptions.type {
             case CaptureType.FACE:
                 self.faceAnalyzer?.reset()
                 
@@ -228,15 +222,15 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
     func captureOutput(
         _ output: AVCaptureOutput,
         didOutput sampleBuffer: CMSampleBuffer,
-        from connection: AVCaptureConnection) {
-                        
+        from connection: AVCaptureConnection
+    ) {
         guard let frame = CMSampleBufferGetImageBuffer(sampleBuffer) else {
             self.cameraEventListener?.onError("Unable to get image from sample buffer.")
             debugPrint("Unable to get image from sample buffer.")
             return
         }
                 
-        switch self.captureOptions.type {
+        switch captureOptions.type {
         case CaptureType.FACE:
             self.faceAnalyzer?.faceDetect(imageBuffer: frame)
             
@@ -257,9 +251,9 @@ extension CameraController: AVCaptureMetadataOutputObjectsDelegate {
     func metadataOutput(
         _ output: AVCaptureMetadataOutput,
         didOutput metadataObjects: [AVMetadataObject],
-        from connection: AVCaptureConnection) {
-
-        if (self.captureOptions.type != CaptureType.QRCODE) {
+        from connection: AVCaptureConnection
+    ) {
+        if (captureOptions.type != CaptureType.QRCODE) {
             return
         }
         

--- a/YoonitCamera/src/CameraView.swift
+++ b/YoonitCamera/src/CameraView.swift
@@ -15,15 +15,15 @@ import AVFoundation
 import UIKit
 import Vision
 
+// Singleton to set CameraView features options.
+var captureOptions: CaptureOptions = CaptureOptions()
+
 /**
  * Class responsible to handle the camera operations.
  */
 @objc
 public class CameraView: UIView {
-    
-    // Model to set CameraView features options.
-    private var captureOptions: CaptureOptions = CaptureOptions()
-    
+                
     // Camera controller object.
     private var cameraController: CameraController? = nil
     
@@ -67,8 +67,7 @@ public class CameraView: UIView {
         self.previewLayer.frame = self.frame
         
         self.cameraController = CameraController(
-            cameraView: self,
-            captureOptions: captureOptions,
+            cameraView: self,            
             session: self.session,
             previewLayer: self.previewLayer)
     }
@@ -121,7 +120,7 @@ public class CameraView: UIView {
      */
     @objc
     public func destroy() {
-        self.captureOptions.type = .NONE
+        captureOptions = CaptureOptions()
         self.cameraController?.destroy()
     }
         
@@ -148,7 +147,7 @@ public class CameraView: UIView {
             ? AVCaptureDevice.Position.front
             : AVCaptureDevice.Position.back
 
-        if self.captureOptions.cameraLens != cameraSelector {
+        if captureOptions.cameraLens != cameraSelector {
             self.cameraController!.toggleCameraLens()
         }
     }
@@ -161,7 +160,7 @@ public class CameraView: UIView {
      */
     @objc
     public func getCameraLens() -> String {
-        return self.captureOptions.cameraLens == AVCaptureDevice.Position.front
+        return captureOptions.cameraLens == AVCaptureDevice.Position.front
             ? "front"
             : "back"
     }
@@ -178,7 +177,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_NUMBER_OF_IMAGES.rawValue)
         }
         
-        self.captureOptions.numberOfImages = numberOfImages
+        captureOptions.numberOfImages = numberOfImages
     }
     
     /**
@@ -193,7 +192,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_TIME_BETWEEN_IMAGES.rawValue)
         }
         
-        self.captureOptions.timeBetweenImages = timeBetweenImages
+        captureOptions.timeBetweenImages = timeBetweenImages
     }
     
     /**
@@ -208,7 +207,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_OUTPUT_IMAGE_WIDTH.rawValue)
         }
         
-        self.captureOptions.imageOutputWidth = width
+        captureOptions.imageOutputWidth = width
     }
     
     /**
@@ -223,7 +222,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_OUTPUT_IMAGE_HEIGHT.rawValue)
         }
         
-        self.captureOptions.imageOutputHeight = height
+        captureOptions.imageOutputHeight = height
     }
     
     /**
@@ -234,7 +233,7 @@ public class CameraView: UIView {
      */
     @objc
     public func setSaveImageCaptured(_ enable: Bool) {
-        self.captureOptions.saveImageCaptured = enable
+        captureOptions.saveImageCaptured = enable
     }
     
     /**
@@ -246,7 +245,8 @@ public class CameraView: UIView {
      */
     @objc
     public func setFaceDetectionBox(_ enable: Bool) {
-        self.captureOptions.faceDetectionBox = enable
+        captureOptions.faceDetectionBox = enable
+//        self.captureOptions.faceDetectionBox = enable
     }
     
     /**
@@ -261,7 +261,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_FACE_PADDING_PERCENT.rawValue)
         }
         
-        self.captureOptions.facePaddingPercent = facePaddingPercent
+        captureOptions.facePaddingPercent = facePaddingPercent
     }
     
     /**
@@ -281,7 +281,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_FACE_CAPTURE_MIN_SIZE.rawValue)
         }
         
-        self.captureOptions.faceCaptureMinSize = faceCaptureMinSize
+        captureOptions.faceCaptureMinSize = faceCaptureMinSize
     }
     
     /**
@@ -301,7 +301,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_FACE_CAPTURE_MAX_SIZE.rawValue)
         }
         
-        self.captureOptions.faceCaptureMaxSize = faceCaptureMaxSize
+        captureOptions.faceCaptureMaxSize = faceCaptureMaxSize
     }
     
     /**
@@ -312,7 +312,7 @@ public class CameraView: UIView {
      */
     @objc
     public func setFaceROIEnable(_ enable: Bool) {
-        self.captureOptions.faceROI.enable = enable
+        captureOptions.faceROI.enable = enable
     }
     
     /**
@@ -327,7 +327,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_FACE_ROI_TOP_OFFSET.rawValue)
         }
 
-        self.captureOptions.faceROI.topOffset = topOffset
+        captureOptions.faceROI.topOffset = topOffset
     }
 
     /**
@@ -342,7 +342,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_FACE_ROI_RIGHT_OFFSET.rawValue)
         }
 
-        self.captureOptions.faceROI.rightOffset = rightOffset
+        captureOptions.faceROI.rightOffset = rightOffset
     }
 
     /**
@@ -357,7 +357,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_FACE_ROI_BOTTOM_OFFSET.rawValue)
         }
 
-        self.captureOptions.faceROI.bottomOffset = bottomOffset
+        captureOptions.faceROI.bottomOffset = bottomOffset
     }
 
     /**
@@ -372,7 +372,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_FACE_ROI_LEFT_OFFSET.rawValue)
         }
 
-        self.captureOptions.faceROI.leftOffset = leftOffset
+        captureOptions.faceROI.leftOffset = leftOffset
     }
     
     /**
@@ -387,7 +387,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_FACE_ROI_MIN_SIZE.rawValue)
         }
         
-        self.captureOptions.faceROI.minimumSize = minimumSize
+        captureOptions.faceROI.minimumSize = minimumSize
     }
 }
 

--- a/YoonitCamera/src/analyzers/face/FaceAnalyzer.swift
+++ b/YoonitCamera/src/analyzers/face/FaceAnalyzer.swift
@@ -26,8 +26,7 @@ class FaceAnalyzer: NSObject {
             self.faceBoundingBoxController.cameraEventListener = cameraEventListener
         }
     }
-    
-    private var captureOptions: CaptureOptions
+        
     private var cameraView: CameraView
     private var previewLayer: AVCaptureVideoPreviewLayer!
     
@@ -50,16 +49,13 @@ class FaceAnalyzer: NSObject {
     }
     
     init(
-        captureOptions: CaptureOptions,
         cameraView: CameraView,
         previewLayer: AVCaptureVideoPreviewLayer) {
         
-        self.captureOptions = captureOptions
         self.cameraView = cameraView
         self.previewLayer = previewLayer
         
         self.faceBoundingBoxController = FaceBoundingBoxController(
-            captureOptions: self.captureOptions,
             cameraView: self.cameraView,
             previewLayer: self.previewLayer)
     }
@@ -171,7 +167,7 @@ class FaceAnalyzer: NSObject {
         self.isValid = true
         
         // Draw face detection box or clean.
-        self.drawings = self.captureOptions.faceDetectionBox ?
+        self.drawings = captureOptions.faceDetectionBox ?
             self.faceBoundingBoxController.makeShapeFor(boundingBox: detectionBox!) : []
         
         // Emit face detected detection box coordinates.
@@ -181,7 +177,7 @@ class FaceAnalyzer: NSObject {
             Int(detectionBox!.width),
             Int(detectionBox!.height))
         
-        if !self.captureOptions.saveImageCaptured {
+        if !captureOptions.saveImageCaptured {
             return
         }
         
@@ -189,21 +185,21 @@ class FaceAnalyzer: NSObject {
         let currentTimestamp = Date().currentTimeMillis()
         let diffTime = currentTimestamp - self.lastTimestamp
         
-        if diffTime > self.captureOptions.timeBetweenImages {
+        if diffTime > captureOptions.timeBetweenImages {
             self.lastTimestamp = currentTimestamp
         
             // Crop the face image.
             self.faceCropController.cropImage(
                 image: image!,
                 boundingBox: closestFace.boundingBox,
-                captureOptions: self.captureOptions) {
+                captureOptions: captureOptions) {
                 
                 // Result of the crop face process.
                 result in
                 
                 let imageResized = try! result.resize(
-                    width: self.captureOptions.imageOutputWidth,
-                    height: self.captureOptions.imageOutputHeight)
+                    width: captureOptions.imageOutputWidth,
+                    height: captureOptions.imageOutputHeight)
                 
                 let fileURL = fileURLFor(index: self.numberOfImages)
                 let fileName = try! save(
@@ -224,14 +220,14 @@ class FaceAnalyzer: NSObject {
     public func handleEmitImageCaptured(filePath: String) {
         
         // process face number of images.
-        if (self.captureOptions.numberOfImages > 0) {
-            if (self.numberOfImages < self.captureOptions.numberOfImages) {
+        if (captureOptions.numberOfImages > 0) {
+            if (self.numberOfImages < captureOptions.numberOfImages) {
                 self.numberOfImages += 1
                 
                 self.cameraEventListener?.onImageCaptured(
                     "face",
                     self.numberOfImages,
-                    self.captureOptions.numberOfImages,
+                    captureOptions.numberOfImages,
                     filePath)
                 
                 return
@@ -247,7 +243,7 @@ class FaceAnalyzer: NSObject {
         self.cameraEventListener?.onImageCaptured(
             "face",
             self.numberOfImages,
-            self.captureOptions.numberOfImages,
+            captureOptions.numberOfImages,
             filePath
         )
     }

--- a/YoonitCamera/src/analyzers/face/FaceBoundingBoxController.swift
+++ b/YoonitCamera/src/analyzers/face/FaceBoundingBoxController.swift
@@ -24,7 +24,6 @@ class FaceBoundingBoxController: NSObject {
     
     private var previewLayer: AVCaptureVideoPreviewLayer
     private var cameraView: CameraView!
-    private var captureOptions: CaptureOptions
     public var cameraEventListener: CameraEventListenerDelegate?
     
     private let topSafeHeight: CGFloat = {
@@ -38,11 +37,9 @@ class FaceBoundingBoxController: NSObject {
     }()
     
     init(
-        captureOptions: CaptureOptions,
         cameraView: CameraView,
-        previewLayer: AVCaptureVideoPreviewLayer) {
-        
-        self.captureOptions = captureOptions
+        previewLayer: AVCaptureVideoPreviewLayer
+    ) {                
         self.cameraView = cameraView
         self.previewLayer = previewLayer
     }
@@ -75,7 +72,7 @@ class FaceBoundingBoxController: NSObject {
         // Normalize the bounding box coordinates to UI.
         let faceBoundingBox = self.previewLayer
             .layerRectConverted(fromMetadataOutputRect: boundingBox)
-            .increase(by: CGFloat(self.captureOptions.facePaddingPercent))
+            .increase(by: CGFloat(captureOptions.facePaddingPercent))
         
         if faceBoundingBox.isNaN() {
             return nil
@@ -126,16 +123,16 @@ class FaceBoundingBoxController: NSObject {
         let detectionBoxRelatedWithScreen = Float(detectionBox!.width / screenWidth)
 
         // Face smaller than the capture minimum size.
-        if (detectionBoxRelatedWithScreen < self.captureOptions.faceCaptureMinSize) {
+        if (detectionBoxRelatedWithScreen < captureOptions.faceCaptureMinSize) {
             return Message.INVALID_CAPTURE_FACE_MIN_SIZE.rawValue
         }
         
         // Face bigger than the capture maximum size.
-        if (detectionBoxRelatedWithScreen > self.captureOptions.faceCaptureMaxSize) {
+        if (detectionBoxRelatedWithScreen > captureOptions.faceCaptureMaxSize) {
             return Message.INVALID_CAPTURE_FACE_MAX_SIZE.rawValue
         }
         
-        if self.captureOptions.faceROI.enable {
+        if captureOptions.faceROI.enable {
             
             // Detection box offsets.
             let topOffset = Float(detectionBox!.minY / screenHeight)
@@ -143,7 +140,7 @@ class FaceBoundingBoxController: NSObject {
             let bottomOffset = Float((screenHeight - detectionBox!.maxY) / screenHeight)
             let leftOffset = Float(detectionBox!.minX / screenWidth)
             
-            if self.captureOptions.faceROI.isOutOf(
+            if captureOptions.faceROI.isOutOf(
                 topOffset: topOffset,
                 rightOffset: rightOffset,
                 bottomOffset: bottomOffset,
@@ -152,18 +149,18 @@ class FaceBoundingBoxController: NSObject {
                 return Message.INVALID_CAPTURE_FACE_OUT_OF_ROI.rawValue
             }
             
-            if self.captureOptions.faceROI.hasChanges {
+            if captureOptions.faceROI.hasChanges {
                 
                 // Face is inside the region of interest and faceROI is setted.
                 // Face is smaller than the defined "minimumSize".
                 let roiWidth: Float =
                     Float(screenWidth) -
-                    ((self.captureOptions.faceROI.rightOffset + self.captureOptions.faceROI.leftOffset) *
+                    ((captureOptions.faceROI.rightOffset + captureOptions.faceROI.leftOffset) *
                         Float(screenWidth))
                 
                 let faceRelatedWithROI: Float = Float(detectionBox!.width) / roiWidth
                                                     
-                if self.captureOptions.faceROI.minimumSize > faceRelatedWithROI {
+                if captureOptions.faceROI.minimumSize > faceRelatedWithROI {
                     return Message.INVALID_CAPTURE_FACE_ROI_MIN_SIZE.rawValue
                 }
             }

--- a/YoonitCamera/src/analyzers/frame/FrameAnalyzer.swift
+++ b/YoonitCamera/src/analyzers/frame/FrameAnalyzer.swift
@@ -22,16 +22,11 @@ class FrameAnalyzer: NSObject {
     private let MAX_NUMBER_OF_IMAGES = 25
     
     public var cameraEventListener: CameraEventListenerDelegate?
-    private var captureOptions: CaptureOptions
         
     private var lastTimestamp = Date().currentTimeMillis()
     private var started = false
     public var numberOfImages = 0
         
-    init(captureOptions: CaptureOptions) {
-        self.captureOptions = captureOptions
-    }
-    
     /**
      Start frame analyzer to capture frame.
      */
@@ -52,15 +47,15 @@ class FrameAnalyzer: NSObject {
         let currentTimestamp = Date().currentTimeMillis()
         let diffTime = currentTimestamp - self.lastTimestamp
         
-        if diffTime > self.captureOptions.timeBetweenImages {
+        if diffTime > captureOptions.timeBetweenImages {
             self.lastTimestamp = currentTimestamp
             
             DispatchQueue.main.async {
-                if (!self.captureOptions.saveImageCaptured) {
+                if (!captureOptions.saveImageCaptured) {
                     return
                 }
                 
-                let orientation = self.captureOptions.cameraLens.rawValue == 1 ?
+                let orientation = captureOptions.cameraLens.rawValue == 1 ?
                     UIImage.Orientation.up : UIImage.Orientation.upMirrored
                 
                 let image = imageFromPixelBuffer(
@@ -86,13 +81,13 @@ class FrameAnalyzer: NSObject {
     func handleEmitImageCaptured(filePath: String) {
         
         // process frame number of images.
-        if (self.captureOptions.numberOfImages > 0) {
-            if (self.numberOfImages < self.captureOptions.numberOfImages) {
+        if (captureOptions.numberOfImages > 0) {
+            if (self.numberOfImages < captureOptions.numberOfImages) {
                 self.numberOfImages += 1
                 self.cameraEventListener?.onImageCaptured(
                     "frame",
                     self.numberOfImages,
-                    self.captureOptions.numberOfImages,
+                    captureOptions.numberOfImages,
                     filePath
                 )
                 return
@@ -108,7 +103,7 @@ class FrameAnalyzer: NSObject {
         self.cameraEventListener?.onImageCaptured(
             "frame",
             self.numberOfImages,
-            self.captureOptions.numberOfImages,
+            captureOptions.numberOfImages,
             filePath
         )
     }

--- a/YoonitCamera/src/models/CaptureOptions.swift
+++ b/YoonitCamera/src/models/CaptureOptions.swift
@@ -14,7 +14,7 @@ import Foundation
 import AVFoundation
 
 /**
- Model to set capture features options.
+ This class is a singleton used in the entire project to handle the features.
  */
 public class CaptureOptions {
     


### PR DESCRIPTION
## :building_construction: Architectural Changes

Change the class `CaptureOptions` to a singleton. This means:
- Unnecessary to pass the instance ahead anymore;
- Unnecessary to create in each class the var `captureOptions`;
- Easy reset `captureOptions` if necessary;