### PR TITLE
[Feature] ROI color

### DIFF
--- a/Example/YoonitCameraDemo/YoonitCameraDemo/Base.lproj/Main.storyboard
+++ b/Example/YoonitCameraDemo/YoonitCameraDemo/Base.lproj/Main.storyboard
@@ -22,21 +22,30 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CFI-Hd-ktB">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CFI-Hd-ktB">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZQn-f6-cka">
-                                        <rect key="frame" x="8" y="52" width="153" height="44"/>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Tu-f8-1DO">
+                                        <rect key="frame" x="8" y="52" width="51" height="31"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" systemColor="scrollViewTexturedBackgroundColor"/>
-                                        <state key="normal" title="Front cam">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        </state>
                                         <connections>
-                                            <action selector="toggleCam:" destination="l7p-dQ-FCU" eventType="touchUpInside" id="u7F-Vr-Lrv"/>
+                                            <action selector="toggleFeatuesPanel:" destination="l7p-dQ-FCU" eventType="valueChanged" id="qvP-JJ-h7s"/>
                                         </connections>
-                                    </button>
+                                    </switch>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Features Panel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vx2-N6-qL9">
+                                        <rect key="frame" x="65" y="57" width="113" height="21"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" title="Camera ON" translatesAutoresizingMaskIntoConstraints="NO" id="ltt-Ps-qeG">
+                                        <rect key="frame" x="206" y="52" width="51" height="31"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <connections>
+                                            <action selector="toggleCameraOn:" destination="l7p-dQ-FCU" eventType="valueChanged" id="p12-Vi-dmp"/>
+                                        </connections>
+                                    </switch>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cye-Bx-CYr">
                                         <rect key="frame" x="206" y="654" width="200" height="200"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
@@ -49,65 +58,146 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NTX-Bi-sU8">
-                                        <rect key="frame" x="8" y="104" width="153" height="44"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <color key="backgroundColor" systemColor="scrollViewTexturedBackgroundColor"/>
-                                        <state key="normal" title="No capture">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="showDropDown:" destination="l7p-dQ-FCU" eventType="touchUpInside" id="xgW-Xh-rmv"/>
-                                        </connections>
-                                    </button>
-                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="07t-4a-cSE">
-                                        <rect key="frame" x="8" y="196" width="49" height="31"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <connections>
-                                            <action selector="toggleFaceDetectionBox:" destination="l7p-dQ-FCU" eventType="valueChanged" id="uuG-6e-qJe"/>
-                                        </connections>
-                                    </switch>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Face Detection Box" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wjl-wb-SKA">
-                                        <rect key="frame" x="63" y="201" width="325" height="21"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="0Nd-tg-26L">
-                                        <rect key="frame" x="8" y="235" width="49" height="31"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <connections>
-                                            <action selector="toggleSaveImageCaptured:" destination="l7p-dQ-FCU" eventType="valueChanged" id="Hvd-WA-6PC"/>
-                                        </connections>
-                                    </switch>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Face Save Image" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sbc-gW-phy">
-                                        <rect key="frame" x="63" y="240" width="325" height="21"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ltt-Ps-qeG">
-                                        <rect key="frame" x="8" y="157" width="49" height="31"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <connections>
-                                            <action selector="toggleCameraOn:" destination="l7p-dQ-FCU" eventType="valueChanged" id="p12-Vi-dmp"/>
-                                        </connections>
-                                    </switch>
+                                    <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="orA-Ae-P4E">
+                                        <rect key="frame" x="0.0" y="99" width="414" height="221"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <subviews>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="0Nd-tg-26L">
+                                                <rect key="frame" x="8" y="8" width="51" height="31"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <connections>
+                                                    <action selector="toggleSaveImageCaptured:" destination="l7p-dQ-FCU" eventType="valueChanged" id="Hvd-WA-6PC"/>
+                                                </connections>
+                                            </switch>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Image Capture" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fLU-8Y-hKV">
+                                                <rect key="frame" x="65" y="13" width="112" height="21"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="07t-4a-cSE">
+                                                <rect key="frame" x="8" y="47" width="51" height="31"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <connections>
+                                                    <action selector="toggleFaceDetectionBox:" destination="l7p-dQ-FCU" eventType="valueChanged" id="uuG-6e-qJe"/>
+                                                </connections>
+                                            </switch>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Face Box" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wjl-wb-SKA">
+                                                <rect key="frame" x="65" y="52" width="69" height="21"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="1AJ-Qd-yiX">
+                                                <rect key="frame" x="8" y="86" width="49" height="31"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <connections>
+                                                    <action selector="onFaceMinSwitchClick:" destination="l7p-dQ-FCU" eventType="valueChanged" id="TuP-ya-D23"/>
+                                                </connections>
+                                            </switch>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VS9-4N-BhW">
+                                                <rect key="frame" x="8" y="125" width="49" height="31"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <connections>
+                                                    <action selector="onFaceROISwitchClick:" destination="l7p-dQ-FCU" eventType="valueChanged" id="dE1-Xg-tzH"/>
+                                                </connections>
+                                            </switch>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="beW-TE-Zpm">
+                                                <rect key="frame" x="204" y="86" width="49" height="31"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <connections>
+                                                    <action selector="onFaceMaxSwitchClick:" destination="l7p-dQ-FCU" eventType="valueChanged" id="gv2-sW-LGg"/>
+                                                </connections>
+                                            </switch>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="8mI-QO-E6m">
+                                                <rect key="frame" x="204" y="125" width="49" height="31"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <connections>
+                                                    <action selector="onFaceROIMinSizeSwitchClick:" destination="l7p-dQ-FCU" eventType="valueChanged" id="OXU-i4-JtX"/>
+                                                </connections>
+                                            </switch>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Face Min 70%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qWI-WE-IT8">
+                                                <rect key="frame" x="65" y="91" width="107" height="21"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Face Max 90%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JS3-Yy-toN">
+                                                <rect key="frame" x="259" y="91" width="113" height="21"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Face ROI" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qwF-OB-7rG">
+                                                <rect key="frame" x="65" y="130" width="68" height="21"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Face ROI Min 70%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="afv-w9-bDK">
+                                                <rect key="frame" x="259" y="130" width="111" height="16"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZQn-f6-cka">
+                                                <rect key="frame" x="253" y="164" width="150" height="44"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                                                <color key="backgroundColor" systemColor="scrollViewTexturedBackgroundColor"/>
+                                                <state key="normal" title="Front cam">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="toggleCam:" destination="l7p-dQ-FCU" eventType="touchUpInside" id="u7F-Vr-Lrv"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NTX-Bi-sU8">
+                                                <rect key="frame" x="8" y="164" width="155" height="44"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <color key="backgroundColor" systemColor="scrollViewTexturedBackgroundColor"/>
+                                                <state key="normal" title="No capture">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="showDropDown:" destination="l7p-dQ-FCU" eventType="touchUpInside" id="xgW-Xh-rmv"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.29883882705479459" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                    </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Camera ON" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1BU-hg-ywQ">
-                                        <rect key="frame" x="63" y="162" width="343" height="21"/>
+                                        <rect key="frame" x="263" y="52" width="89" height="31"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <textField hidden="YES" opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="22" translatesAutoresizingMaskIntoConstraints="NO" id="AFu-Sx-gtE" userLabel="Image Captured Text Field">
+                                        <rect key="frame" x="8" y="820" width="100" height="34"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                        <color key="backgroundColor" red="0.46269756449999999" green="0.46309917639999998" blue="0.5" alpha="0.60493364729999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="8WE-KQ-cXS"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="CFI-Hd-ktB" secondAttribute="bottom" id="KlP-bA-6JJ"/>
+                            <constraint firstItem="CFI-Hd-ktB" firstAttribute="leading" secondItem="8WE-KQ-cXS" secondAttribute="leading" id="ZNv-Mo-IpT"/>
+                            <constraint firstItem="CFI-Hd-ktB" firstAttribute="top" secondItem="hFs-or-lPB" secondAttribute="top" id="ql2-O5-Tmw"/>
+                            <constraint firstItem="CFI-Hd-ktB" firstAttribute="trailing" secondItem="8WE-KQ-cXS" secondAttribute="trailing" id="vZL-Nj-Bgd"/>
+                        </constraints>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <nil key="simulatedTopBarMetrics"/>
@@ -117,7 +207,9 @@
                         <outlet property="cameraTypeDropDown" destination="NTX-Bi-sU8" id="rh9-fq-g8S"/>
                         <outlet property="cameraView" destination="s7c-6p-oqC" id="tUf-Wq-rUD"/>
                         <outlet property="faceDetectionBoxSwitch" destination="07t-4a-cSE" id="3YP-fx-Kkq"/>
+                        <outlet property="featuresPanel" destination="orA-Ae-P4E" id="5fv-nD-xPg"/>
                         <outlet property="imageCaptureSwitch" destination="0Nd-tg-26L" id="eQe-0L-E13"/>
+                        <outlet property="imageCapturedTextField" destination="AFu-Sx-gtE" id="Dg6-Ke-VGs"/>
                         <outlet property="qrCodeTextField" destination="v8g-XX-tYC" id="ODX-Wv-8me"/>
                         <outlet property="savedFrame" destination="cye-Bx-CYr" id="fa9-d9-e9O"/>
                     </connections>

--- a/YoonitCamera/src/CameraController.swift
+++ b/YoonitCamera/src/CameraController.swift
@@ -163,10 +163,10 @@ class CameraController: NSObject {
         guard let device = AVCaptureDevice.DiscoverySession(
             deviceTypes: [.builtInWideAngleCamera],
             mediaType: .video,
-            position: cameraLens).devices.first
-            else {
-                self.cameraEventListener?.onError("You have a problem with your camera, please verify the settings of the your camera")
-                fatalError("No back camera device found, please make sure to run in an iOS device and not a simulator")
+            position: cameraLens
+        ).devices.first else {
+            self.cameraEventListener?.onError("You have a problem with your camera, please verify the settings of the your camera")
+            fatalError("No back camera device found, please make sure to run in an iOS device and not a simulator")
         }
                 
         let cameraInput = try! AVCaptureDeviceInput(device: device)

--- a/YoonitCamera/src/CameraController.swift
+++ b/YoonitCamera/src/CameraController.swift
@@ -114,7 +114,7 @@ class CameraController: NSObject {
             self.faceAnalyzer?.start = true
             
         case CaptureType.FRAME:
-            self.frameAnalyzer?.start()
+            self.frameAnalyzer?.start = true
             
         default:
             return
@@ -126,9 +126,7 @@ class CameraController: NSObject {
      */
     public func stopAnalyzer() {
         self.faceAnalyzer?.start = false
-            
-        self.frameAnalyzer?.stop()
-        self.frameAnalyzer?.numberOfImages = 0
+        self.frameAnalyzer?.start = false
     }
         
     /**
@@ -149,14 +147,6 @@ class CameraController: NSObject {
             
             // Add camera input.
             self.buildCameraInput(cameraLens: captureOptions.cameraLens)
-                                    
-            switch captureOptions.type {
-            case CaptureType.FRAME:
-                self.frameAnalyzer?.reset()
-                
-            default:
-                return
-            }
         }
     }
     
@@ -166,6 +156,9 @@ class CameraController: NSObject {
      - Parameter cameraLens: the enum of the camera lens facing;
      */
     private func buildCameraInput(cameraLens: AVCaptureDevice.Position) {
+        
+        self.faceAnalyzer?.numberOfImages = 0
+        self.frameAnalyzer?.numberOfImages = 0
         
         guard let device = AVCaptureDevice.DiscoverySession(
             deviceTypes: [.builtInWideAngleCamera],

--- a/YoonitCamera/src/CameraGraphicView.swift
+++ b/YoonitCamera/src/CameraGraphicView.swift
@@ -39,6 +39,14 @@ public class CameraGraphicView: UIView {
     public override func draw(_ rect: CGRect) {
         guard let context = UIGraphicsGetCurrentContext() else { return }
         
+        // Draw face region of interest area offset bitmap.
+        let isDrawFaceROIAreaOffset: Bool =
+            captureOptions.faceROI.enable &&
+            captureOptions.faceROI.areaOffsetEnable
+        if isDrawFaceROIAreaOffset {
+            self.drawFaceROIAreaOffset(context: context, rect: rect)
+        }
+        
         // Draw face detection box.
         if captureOptions.faceDetectionBox {
             self.drawFaceDetectionBox(context: context)
@@ -138,6 +146,30 @@ public class CameraGraphicView: UIView {
                 to: CGPoint(x: right - (midY * 0.5), y: bottom)
             )
         }
+    }
+    
+    /**
+     Draw the face region of interest area offset bitmap.
+     
+     - Parameter context The UI graphic view context.
+     - Parameter rect The rect abaiable to draw..
+     */
+    func drawFaceROIAreaOffset(context: CGContext, rect: CGRect) {
+        let topOffset: CGFloat = rect.height * captureOptions.faceROI.topOffset
+        let rightOffset: CGFloat = rect.width * captureOptions.faceROI.rightOffset
+        let bottomOffset: CGFloat = rect.height * captureOptions.faceROI.bottomOffset
+        let leftOffset: CGFloat = rect.width * captureOptions.faceROI.leftOffset
+        
+        let smallRect: CGRect = CGRect(
+            x: leftOffset,
+            y: topOffset,
+            width: rect.width - (rightOffset + leftOffset),
+            height: rect.height - (topOffset + bottomOffset)
+        )
+        
+        context.setFillColor(captureOptions.faceROI.areaOffsetColor.cgColor)
+        context.fill(rect)
+        context.clear(smallRect)
     }
                 
     func drawLine(

--- a/YoonitCamera/src/CameraView.swift
+++ b/YoonitCamera/src/CameraView.swift
@@ -392,5 +392,49 @@ public class CameraView: UIView {
         
         captureOptions.faceROI.minimumSize = minimumSize
     }
+    
+    /**
+     Set face region of interest offset color visibility.
+     
+     - Parameter enable: The indicator to show/hide the face region of interest area offset.
+     Default value is `false`.
+     */
+    @objc
+    public func setFaceROIAreaOffset(_ enable: Bool) {
+        captureOptions.faceROI.areaOffsetEnable = enable
+    }
+
+    /**
+     Set face region of interest area offset color.
+     
+     - Parameter red: Float that represent red color.
+     - Parameter green: Float that represent green color.
+     - Parameter blue: Float that represent blue color.
+     - Parameter alpha: Float that represents the alpha.
+     Default value is 100, 255, 255, 255 (white color).
+     */
+    @objc
+    public func setFaceROIAreaOffsetColor(
+        _ alpha: Float,
+        _ red: Float,
+        _ green: Float,
+        _ blue: Float
+    ) {
+        if (
+            alpha < 0.0 || alpha > 1.0 ||
+            red < 0.0 || red > 1.0 ||
+            green < 0.0 || green > 1.0 ||
+            blue < 0.0 || blue > 1.0
+        ) {
+            fatalError(KeyError.INVALID_FACE_ROI_COLOR.rawValue)
+        }
+            
+        captureOptions.faceROI.areaOffsetColor = UIColor(
+            red: CGFloat(red),
+            green: CGFloat(green),
+            blue: CGFloat(blue),
+            alpha: CGFloat(alpha)
+        )
+    }
 }
 

--- a/YoonitCamera/src/CameraView.swift
+++ b/YoonitCamera/src/CameraView.swift
@@ -330,7 +330,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_FACE_ROI_TOP_OFFSET.rawValue)
         }
 
-        captureOptions.faceROI.topOffset = topOffset
+        captureOptions.faceROI.topOffset = CGFloat(topOffset)
     }
 
     /**
@@ -345,7 +345,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_FACE_ROI_RIGHT_OFFSET.rawValue)
         }
 
-        captureOptions.faceROI.rightOffset = rightOffset
+        captureOptions.faceROI.rightOffset = CGFloat(rightOffset)
     }
 
     /**
@@ -360,7 +360,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_FACE_ROI_BOTTOM_OFFSET.rawValue)
         }
 
-        captureOptions.faceROI.bottomOffset = bottomOffset
+        captureOptions.faceROI.bottomOffset = CGFloat(bottomOffset)
     }
 
     /**
@@ -375,7 +375,7 @@ public class CameraView: UIView {
             fatalError(KeyError.INVALID_FACE_ROI_LEFT_OFFSET.rawValue)
         }
 
-        captureOptions.faceROI.leftOffset = leftOffset
+        captureOptions.faceROI.leftOffset = CGFloat(leftOffset)
     }
     
     /**

--- a/YoonitCamera/src/KeyError.swift
+++ b/YoonitCamera/src/KeyError.swift
@@ -55,4 +55,7 @@ public enum KeyError: String {
 
     // Tried to input invalid face region of interest minimum size.
     case INVALID_FACE_ROI_MIN_SIZE = "INVALID_FACE_ROI_MIN_SIZE"
+    
+    // Tried to input invalid face region of interest area offset ARGB value color.
+    case INVALID_FACE_ROI_COLOR = "INVALID_FACE_ROI_COLOR"
 }

--- a/YoonitCamera/src/analyzers/face/FaceBoundingBoxController.swift
+++ b/YoonitCamera/src/analyzers/face/FaceBoundingBoxController.swift
@@ -119,17 +119,17 @@ class FaceBoundingBoxController: NSObject {
         if captureOptions.faceROI.enable {
             
             // Detection box offsets.
-            let topOffset = Float(detectionBox!.minY / screenHeight)
-            let rightOffset = Float((screenWidth - detectionBox!.maxX) / screenWidth)
-            let bottomOffset = Float((screenHeight - detectionBox!.maxY) / screenHeight)
-            let leftOffset = Float(detectionBox!.minX / screenWidth)
+            let topOffset = CGFloat(detectionBox!.minY / screenHeight)
+            let rightOffset = CGFloat((screenWidth - detectionBox!.maxX) / screenWidth)
+            let bottomOffset = CGFloat((screenHeight - detectionBox!.maxY) / screenHeight)
+            let leftOffset = CGFloat(detectionBox!.minX / screenWidth)
             
             if captureOptions.faceROI.isOutOf(
                 topOffset: topOffset,
                 rightOffset: rightOffset,
                 bottomOffset: bottomOffset,
-                leftOffset: leftOffset) {
-                                
+                leftOffset: leftOffset
+            ) {
                 return Message.INVALID_CAPTURE_FACE_OUT_OF_ROI.rawValue
             }
             
@@ -139,7 +139,7 @@ class FaceBoundingBoxController: NSObject {
                 // Face is smaller than the defined "minimumSize".
                 let roiWidth: Float =
                     Float(screenWidth) -
-                    ((captureOptions.faceROI.rightOffset + captureOptions.faceROI.leftOffset) *
+                    (Float(captureOptions.faceROI.rightOffset + captureOptions.faceROI.leftOffset) *
                         Float(screenWidth))
                 
                 let faceRelatedWithROI: Float = Float(detectionBox!.width) / roiWidth

--- a/YoonitCamera/src/analyzers/frame/FrameAnalyzer.swift
+++ b/YoonitCamera/src/analyzers/frame/FrameAnalyzer.swift
@@ -22,28 +22,22 @@ class FrameAnalyzer: NSObject {
     private let MAX_NUMBER_OF_IMAGES = 25
     
     public var cameraEventListener: CameraEventListenerDelegate?
-        
-    private var lastTimestamp = Date().currentTimeMillis()
-    private var started = false
+    public var start = false {
+        didSet {
+            if !self.start {
+                self.numberOfImages = 0
+            }
+        }
+    }
     public var numberOfImages = 0
-        
-    /**
-     Start frame analyzer to capture frame.
-     */
-    func start() {
-        self.started = true
-    }
-        
-    func stop() {
-        self.started = false
-    }
     
-    func reset() {
-        self.stop()
-        self.start()
-    }
-    
+    private var lastTimestamp = Date().currentTimeMillis()
+            
     func frameCaptured(imageBuffer: CVPixelBuffer) {
+        if !self.start {
+            return
+        }
+        
         let currentTimestamp = Date().currentTimeMillis()
         let diffTime = currentTimestamp - self.lastTimestamp
         
@@ -61,12 +55,14 @@ class FrameAnalyzer: NSObject {
                 let image = imageFromPixelBuffer(
                     imageBuffer: imageBuffer,
                     scale: UIScreen.main.scale,
-                    orientation: orientation)
+                    orientation: orientation
+                )
                                         
                 let fileURL = fileURLFor(index: self.numberOfImages)
                 let filePath = try! save(
                     image: image,
-                    fileURL: fileURL)
+                    fileURL: fileURL
+                )
                 
                 self.handleEmitImageCaptured(filePath: filePath)
             }
@@ -93,7 +89,7 @@ class FrameAnalyzer: NSObject {
                 return
             }
             
-            self.stop()
+            self.start = false
             self.cameraEventListener?.onEndCapture()
             return
         }

--- a/YoonitCamera/src/models/FaceROI.swift
+++ b/YoonitCamera/src/models/FaceROI.swift
@@ -25,7 +25,7 @@ public class FaceROI {
     var areaOffsetEnable: Bool = false
 
     // Face region of interest area offset color.
-    var areaOffsetColor: UIColor = UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.5)
+    var areaOffsetColor: UIColor = UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.4)
     
     // Region of interest in percentage.
     // Values valid [0, 1].

--- a/YoonitCamera/src/models/FaceROI.swift
+++ b/YoonitCamera/src/models/FaceROI.swift
@@ -9,7 +9,7 @@
 // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 //
 
-
+import UIKit
 import Foundation
 import AVFoundation
 
@@ -20,6 +20,12 @@ public class FaceROI {
     
     // Enable or disable ROI.
     var enable: Bool = false
+    
+    // Enable or disable face region of interest area offset.
+    var areaOffsetEnable: Bool = false
+
+    // Face region of interest area offset color.
+    var areaOffsetColor: UIColor = UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
     
     // Region of interest in percentage.
     // Values valid [0, 1].

--- a/YoonitCamera/src/models/FaceROI.swift
+++ b/YoonitCamera/src/models/FaceROI.swift
@@ -25,14 +25,14 @@ public class FaceROI {
     var areaOffsetEnable: Bool = false
 
     // Face region of interest area offset color.
-    var areaOffsetColor: UIColor = UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+    var areaOffsetColor: UIColor = UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.5)
     
     // Region of interest in percentage.
     // Values valid [0, 1].
-    var topOffset: Float = 0     // "Above" the face detected.
-    var rightOffset: Float = 0   // "Right" of face detected.
-    var bottomOffset: Float = 0  // "Bottom" face detected.
-    var leftOffset: Float = 0    // "Left" face detected.
+    var topOffset: CGFloat = 0     // "Above" the face detected.
+    var rightOffset: CGFloat = 0   // "Right" of face detected.
+    var bottomOffset: CGFloat = 0  // "Bottom" face detected.
+    var leftOffset: CGFloat = 0    // "Left" face detected.
     
     // Minimum face size in percentage in relation of the ROI.
     var minimumSize: Float = 0
@@ -58,11 +58,11 @@ public class FaceROI {
      - Returns is out of the offset parameters.
      */
     public func isOutOf(
-        topOffset: Float,
-        rightOffset: Float,
-        bottomOffset: Float,
-        leftOffset: Float) -> Bool {
-        
+        topOffset: CGFloat,
+        rightOffset: CGFloat,
+        bottomOffset: CGFloat,
+        leftOffset: CGFloat
+    ) -> Bool {
         return
             self.topOffset > topOffset ||
             self.rightOffset > rightOffset ||


### PR DESCRIPTION
## ✨ New Feature

### Face ROI Area Offset
- Add new method, `setFaceROIAreaOffset`, to enable or disable the face region of interest area offset. Must have one of the values (top, right, bottom or left) different from `0`;
- Add new method, `setFaceROIAreaOffsetColor`, to change the region of interest area offset ARGB value color. Default color is white with opacity value of 0.4;

## :memo: Update Readme

- Add method `setFaceROIAreaOffset` definitions;
- Add method `setFaceROIAreaOffsetColor` definitions;
- Add new `KeyError` `INVALID_FACE_ROI_COLOR` definitions;

| Function                  | Parameters                                            | Valid values                           | Return Type | Description
| -                         | -                                                     | -                                      | -           | -
| setFaceROIAreaOffset      | `enable: Bool`                                        | `true` or `false`                      | void        | Set face region of interest offset color visibility.
| setFaceROIAreaOffsetColor | `alpha: Float, red: Float, green: Float, blue: Float` | Any positive float between 0.0 and 1.0 | void        | Set face region of interest area offset color. Default value is (0.4, 1.0, 1.0, 1.0).

| KeyError               | Description
| -                      | -
| INVALID_FACE_ROI_COLOR | Tried to input invalid face region of interest area offset ARGB value color.